### PR TITLE
Use updated Atlas Organization name to match new Atlas API credentials

### DIFF
--- a/astrolabe/configuration.py
+++ b/astrolabe/configuration.py
@@ -17,7 +17,7 @@ from collections import namedtuple
 from atlasclient.utils import JSONObject
 
 CONFIG_DEFAULTS = JSONObject.from_dict({
-    "ORGANIZATION_NAME": "MongoDB",
+    "ORGANIZATION_NAME": "MongoDB Drivers Team",
     "DB_USERNAME": "atlasuser",
     "DB_PASSWORD": "mypassword123",
     "POLLING_TIMEOUT": 1200.0,


### PR DESCRIPTION
Related to #18 