### PR TITLE
Make astrolabe resilient to CLOUDP-61574

### DIFF
--- a/atlasclient/exceptions.py
+++ b/atlasclient/exceptions.py
@@ -56,6 +56,9 @@ class AtlasApiError(AtlasApiBaseError):
 
         super().__init__(msg, **kwargs)
 
+        # Store complete response (or None).
+        self.raw_response = response
+
 
 class AtlasRateLimitError(AtlasApiError):
     pass


### PR DESCRIPTION
Related to #56 

Enables astrolabe to parse NOT_ATLAS_GROUP error response for the ID of the Atlas Project being requested. The main idea here is that we need the project ID in order to perform an operation on the project (e.g. populating its IP whitelist) in order for Atlas to successfully populate the project metadata so that we may use the project as normal.

Just opening this for visibility at the moment, since this 'workaround' isn't actually sufficient to resolve the issues we face when using the Atlas API. Follow https://jira.mongodb.org/browse/HELP-15367 for details.