### PR TITLE
Migrate linux builds to ubuntu1804-drivers-atlas-testing

### DIFF
--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -24,6 +24,12 @@ functions:
     - command: git.get_project
       params:
         directory: astrolabe-src
+    # Make sure virtualenv is installed.
+    - command: subprocess.exec
+      params:
+        working_dir: astrolabe-src
+        command: |
+          ${PYTHON3_BINARY} -m pip install virtualenv
     # Create virtualenv using a CPython 3.5+ binary.
     - command: subprocess.exec
       params:
@@ -152,13 +158,16 @@ axes:
   - id: platform
     display_name: OS
     values:
-      - id: ubuntu-16.04
-        display_name: "Ubuntu 16.04"
-        run_on: ubuntu1604-test
+      - id: ubuntu-18.04
+        display_name: "Ubuntu 18.04"
+        run_on: ubuntu1804-drivers-atlas-testing
         batchtime: 10080  # 7 days
         variables:
-          PYTHON3_BINARY: "/opt/python/3.7/bin/python3"
+          PYTHON3_BINARY: "python3"
           PYTHON_BIN_DIR: "bin"
+          # Set locale to unicode - needed for astrolabe to function correctly.
+          LC_ALL: "C.UTF-8"
+          LANG: "C.UTF-8"
       - id: windows-64
         display_name: "Windows 64"
         run_on: windows-64-vsMulti-small
@@ -173,13 +182,13 @@ axes:
     display_name: runtime
     values:
       - id: python27
-        display_name: CPython-2.7
+        display_name: CPython-2
         variables:
-          PYTHON_BINARY: "/opt/python/2.7/bin/python"
+          PYTHON_BINARY: "python"
       - id: python38
-        display_name: CPython-3.8
+        display_name: CPython-3
         variables:
-          PYTHON_BINARY: "/opt/python/3.8/bin/python3"
+          PYTHON_BINARY: "python3"
       - id: python37-windows
         display_name: CPython-3.7-Windows
         variables:
@@ -189,7 +198,7 @@ buildvariants:
 - matrix_name: "tests-python"
   matrix_spec:
     driver: ["pymongo-master"]
-    platform: ["ubuntu-16.04"]
+    platform: ["ubuntu-18.04"]
     runtime: ["python27", "python38"]
   display_name: "${driver} ${platform} ${runtime}"
   tasks:

--- a/docs/source/faq.rst
+++ b/docs/source/faq.rst
@@ -3,8 +3,8 @@ Frequently Asked Questions
 
 .. contents::
 
-Why do I keep seeing ``atlasclient.exceptions.AtlasAuthenticationError: 401: Unauthorized.`` errors?
-----------------------------------------------------------------------------------------------------
+Why do I keep seeing ``AtlasAuthenticationError: 401: Unauthorized.`` errors while trying to use ``astrolabe``?
+---------------------------------------------------------------------------------------------------------------
 
 Applications can only be granted programmatic access to MongoDB Atlas using an
 `API key <https://docs.atlas.mongodb.com/configure-api-access/#programmatic-api-keys>`_. If you are
@@ -23,3 +23,21 @@ how to create programmatic API keys.
 
     $ ATLAS_API_USERNAME=<publicKey> ATLAS_API_PASSWORD=<privateKey> astrolabe check-connection
 
+.. _faq-why-custom-distro:
+
+Why should we use the custom ``ubuntu1804-drivers-atlas-testing`` distro?
+-------------------------------------------------------------------------
+
+MongoDB Atlas restricts the number of clusters in an Atlas Project to 25. Since
+`this project <https://github.com/mongodb-labs/drivers-atlas-testing>`_ runs the entire
+build matrix in its in
+`evergreen configuration <https://github.com/mongodb-labs/drivers-atlas-testing/blob/master/.evergreen/config.yml>`_
+under a single Atlas project, it often ends up running into this limitation which causes
+hard-to-diagnose test failures (see `#45 <https://github.com/mongodb-labs/drivers-atlas-testing/issues/45>`_,
+`#46 <https://github.com/mongodb-labs/drivers-atlas-testing/issues/46>`_, and
+`#48 <https://github.com/mongodb-labs/drivers-atlas-testing/issues/45>`_). To mitigate this issue,
+we need to limit the number of concurrent builds in the
+`drivers-atlas-testing <https://evergreen.mongodb.com/waterfall/drivers-atlas-testing>`_ Evergreen project to less
+than 25. Evergreen does not currently have a way to enforce such a limit, so instead we have created this
+custom distro which is limited to 25 hosts. While not foolproof, this workaround helps avoid the aforementioned
+failures in most usage scenarios.

--- a/docs/source/integration-guide.rst
+++ b/docs/source/integration-guide.rst
@@ -126,6 +126,11 @@ are in place.
 Adding a Platform
 -----------------
 
+.. attention:: Drivers wanting to run the Atlas Planned Maintenance test-suite on Linux systems
+   are **strongly advised** to use the custom
+   `ubuntu1804-drivers-atlas-testing <https://evergreen.mongodb.com/distros#%23ubuntu1804-drivers-atlas-testing>`_
+   distro for running their tests. See :ref:`faq-why-custom-distro` for details.
+
 The Atlas Planned Maintenance tests can be run on all platforms which have a Python 3.5+ binary installed.
 Each entry to the ``platform`` axis has the following fields:
 

--- a/integrations/python/pymongo/install-driver.sh
+++ b/integrations/python/pymongo/install-driver.sh
@@ -1,6 +1,7 @@
 #!/bin/sh
 set -o xtrace
 
+"$PYTHON_BINARY" --version
 "$PYTHON_BINARY" -m virtualenv "$PYMONGO_VIRTUALENV_NAME"
 "$PYMONGO_VIRTUALENV_NAME/$PYTHON_BIN_DIR/pip" install -e mongo-python-driver/[srv]
 "$PYMONGO_VIRTUALENV_NAME/$PYTHON_BIN_DIR/pip" install certifi    # TODO: remove this once BUILD-10841 is done.


### PR DESCRIPTION
Closes #62 
Closes #48 (kind of - it doesn't actually solve this problem in a foolproof manner because if we add more platforms, we could end up running more than N concurrent builds where N is the maximum number of instances of `ubuntu1804-drivers-atlas-testing`).