### PR TITLE
Enable running workload executor validation as an evergreen patch-build

### DIFF
--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -82,6 +82,22 @@ functions:
         command: |
           astrolabevenv/${PYTHON_BIN_DIR}/astrolabe spec-tests run-one tests/${TEST_NAME}.yaml -e integrations/${DRIVER_DIRNAME}/workload-executor
 
+  "validate executor":
+    # Run a MongoDB instance locally.
+    - command: shell.exec
+      params:
+        working_dir: astrolabe-src
+        script: |
+          sh .evergreen/run-mongodb.sh
+    # Validate the workload executor against the local MongoDB instance.
+    - command: subprocess.exec
+      type: test
+      params:
+        working_dir: astrolabe-src
+        add_expansions_to_env: true
+        command: |
+          astrolabevenv/${PYTHON_BIN_DIR}/astrolabe spec-tests validate-workload-executor -e integrations/${DRIVER_DIRNAME}/workload-executor --connection-string "mongodb://localhost:27017/"
+
   "delete test cluster":
     # Delete the cluster that was used to run the test.
     - command: subprocess.exec
@@ -113,31 +129,37 @@ post:
   - func: "upload test results"
 
 tasks:
-    # One test-case per task.
-    - name: retryReads-resizeCluster
-      tags: ["all", "retryReads", "resizeCluster"]
-      commands:
-        - func: "run test"
-          vars:
-            TEST_NAME: retryReads-resizeCluster
-    - name: retryReads-toggleServerSideJS
-      tags: ["all", "retryReads", "toggleServerSideJS"]
-      commands:
-        - func: "run test"
-          vars:
-            TEST_NAME: retryReads-toggleServerSideJS
-    - name: retryWrites-resizeCluster
-      tags: ["all", "retryWrites", "resizeCluster"]
-      commands:
-        - func: "run test"
-          vars:
-            TEST_NAME: retryWrites-resizeCluster
-    - name: retryWrites-toggleServerSideJS
-      tags: ["all", "retryWrites", "toggleServerSideJS"]
-      commands:
-        - func: "run test"
-          vars:
-            TEST_NAME: retryWrites-toggleServerSideJS
+  # Workload executor validation task (patch-only).
+  - name: validate-workload-executor
+    patch_only: true
+    tags: ["all"]
+    commands:
+      - func: "validate executor"
+  # One test-case per task.
+  - name: retryReads-resizeCluster
+    tags: ["all", "retryReads", "resizeCluster"]
+    commands:
+      - func: "run test"
+        vars:
+          TEST_NAME: retryReads-resizeCluster
+  - name: retryReads-toggleServerSideJS
+    tags: ["all", "retryReads", "toggleServerSideJS"]
+    commands:
+      - func: "run test"
+        vars:
+          TEST_NAME: retryReads-toggleServerSideJS
+  - name: retryWrites-resizeCluster
+    tags: ["all", "retryWrites", "resizeCluster"]
+    commands:
+      - func: "run test"
+        vars:
+          TEST_NAME: retryWrites-resizeCluster
+  - name: retryWrites-toggleServerSideJS
+    tags: ["all", "retryWrites", "toggleServerSideJS"]
+    commands:
+      - func: "run test"
+        vars:
+          TEST_NAME: retryWrites-toggleServerSideJS
 
 axes:
   # The 'driver' axis specifies the driver to be tested (including driver version).

--- a/.evergreen/run-mongodb.sh
+++ b/.evergreen/run-mongodb.sh
@@ -1,0 +1,34 @@
+#!/bin/sh
+set -o xtrace
+
+# User configurable-options
+export MONGODB_VERSION="4.2"
+export TOPOLOGY="server"
+
+# Setup variables
+export DRIVERS_TOOLS="$(dirname $(pwd))/drivers-tools"
+if [ "Windows_NT" = "$OS" ]; then
+   export DRIVERS_TOOLS=$(cygpath -m $DRIVERS_TOOLS)
+fi
+export MONGODB_BINARIES="$DRIVERS_TOOLS/mongodb/bin"
+export MONGO_ORCHESTRATION_HOME="$DRIVERS_TOOLS/.evergreen/orchestration"
+export PATH="$MONGODB_BINARIES:$PATH"
+
+# Clone drivers-evergreen-tools
+git clone --recursive git://github.com/mongodb-labs/drivers-evergreen-tools.git $DRIVERS_TOOLS
+
+# Configure mongo-orchestration
+echo "{ \"releases\": { \"default\": \"$MONGODB_BINARIES\" }}" > $MONGO_ORCHESTRATION_HOME/orchestration.config
+
+# Fix absolute paths
+for filename in $(find ${DRIVERS_TOOLS} -name \*.json); do
+  perl -p -i -e "s|ABSOLUTE_PATH_REPLACEMENT_TOKEN|${DRIVERS_TOOLS}|g" $filename
+done
+
+# Make files executable
+for i in $(find ${DRIVERS_TOOLS}/.evergreen -name \*.sh); do
+  chmod +x $i
+done
+
+# Run mongo-orchestration
+sh $DRIVERS_TOOLS/.evergreen/run-orchestration.sh

--- a/astrolabe/cli.py
+++ b/astrolabe/cli.py
@@ -523,7 +523,7 @@ def run_headless(ctx, spec_tests_directory, workload_executor, db_username,
 @click.option('--connection-string', required=True, type=click.STRING,
               help='Connection string for the test MongoDB instance.',
               prompt=True)
-@click.option('--startup-time', default=3, type=click.FLOAT, show_default=True,
+@click.option('--startup-time', default=1, type=click.FLOAT, show_default=True,
               help='Amount of time to wait for the executor to start.')
 def validate_workload_executor(workload_executor, connection_string,
                                startup_time):
@@ -534,7 +534,9 @@ def validate_workload_executor(workload_executor, connection_string,
     test_case_class = validator_factory(
         workload_executor, connection_string, startup_time)
     suite = unittest.defaultTestLoader.loadTestsFromTestCase(test_case_class)
-    unittest.TextTestRunner(descriptions=True, verbosity=2).run(suite)
+    result = unittest.TextTestRunner(descriptions=True, verbosity=2).run(suite)
+    if any([result.errors, result.failures]):
+        exit(1)
 
 
 if __name__ == '__main__':

--- a/docs/source/integration-guide.rst
+++ b/docs/source/integration-guide.rst
@@ -69,7 +69,7 @@ Wrapping native workload executors with a shell script
 
 Different languages will have different kinds of workload executors. Compiled languages, for example, might have
 as their workload executor a standalone binary whereas interpreted languages would likely use a script that
-would need to be executed using the appropriate interpreter. Furthermore, drivers may need to employ different
+needs to be invoked using an interpreter. Furthermore, drivers may need to employ different
 workload executor scripts on different platforms. To support these various usage scenarios, users can
 wrap the actual call to a natively implemented workload executor in a shell script such that exposes the
 API desired by the :ref:`workload-executor-specification` specification.
@@ -78,6 +78,30 @@ API desired by the :ref:`workload-executor-specification` specification.
 
    For example, PyMongo's ``astrolabe`` integration uses this pattern to implement its
    `workload executor <https://github.com/mongodb-labs/drivers-atlas-testing/blob/master/integrations/python/pymongo/workload-executor>`_.
+
+Testing/validating a workload executor script
+---------------------------------------------
+
+Workload executor scripts are cumbersome to test due to the amount of setup required before they can be
+invoked. In order to test a workload executor, at a minimum, you need:
+
+* an ``astrolabe`` installation,
+* an installation of the driver whose workload executor is to be tested,
+* a connection string to the MongoDB instance against which the workload executor will run operations, and
+* a test YAML file containing a driver workload that can be used to run the test.
+
+While you can always run a patch build with the workload executor (having first updated the evergreen configuration
+as outlined in :ref:`integration-step-evergreen-configuration` of course), your builds will take a while
+to complete (provisioning Atlas clusters takes time) resulting in a large wait before you can check whether
+the workload executor behaved as expected.
+
+To streamline the process of testing your workload executor implementation, the ``drivers-atlas-testing`` Evergreen
+project offers a special task called ``validate-workload-executor``. This task spins up a MongoDB cluster on the
+Evergreen test instance and runs a series of checks against the workload executor that has been provided. It may
+be used during the implementation of workload executors as a convenient way to test script functionality.
+
+.. note:: The ``validate-workload-executor`` task only appears on patch builds.
+
 
 .. _integration-step-driver-installer:
 


### PR DESCRIPTION
Closes #66 
Closes #67 