### PR TITLE
CSHARP-2515: Test Planned Maintenance Scenarios in Drivers

### DIFF
--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -181,6 +181,19 @@ axes:
           DRIVER_DIRNAME: "ruby"
           DRIVER_REPOSITORY: "https://github.com/mongodb/mongo-ruby-driver"
           DRIVER_REVISION: "master"
+      - id: dotnet-csharp2515
+        display_name: "dotnet (csharp2515)"
+        variables:
+          DRIVER_DIRNAME: "dotnet"
+          DRIVER_REPOSITORY: "https://github.com/vincentkam/mongo-csharp-driver"
+          DRIVER_REVISION: "csharp2515"
+          ASTROLABE_EXECUTOR_STARTUP_TIME: 40
+          DOTNET_CLI_HOME: "Z:/"
+          TMP: "Z:/"
+          TEMP: "Z:/"
+          NUGET_PACKAGES: "Z:/"
+          NUGET_HTTP_CACHE_PATH: "Z:/"
+          APPDATA: "Z:/"
 
   # The 'platform' axis specifies the evergreen host distro to use.
   # Platforms MUST specify the PYTHON3_BINARY variable as this is required to install astrolabe.
@@ -222,6 +235,36 @@ axes:
         display_name: CPython-3.7-Windows
         variables:
           PYTHON_BINARY: "C:/python/Python37/python.exe"
+      - id: dotnet-async-netcoreapp2.1
+        display_name: dotnet-async-netcoreapp2.1
+        variables:
+          ASYNC: "true"
+          FRAMEWORK: "netcoreapp2.1"
+      - id: "dotnet-sync-netcoreapp2.1"
+        display_name: dotnet-sync-netcoreapp2.1
+        variables:
+          ASYNC: "false"
+          FRAMEWORK: "netcoreapp2.1"
+      - id: "dotnet-async-netcoreapp1.1"
+        display_name: dotnet-async-netcoreapp1.1
+        variables:
+          ASYNC: "true"
+          FRAMEWORK: "netcoreapp1.1"
+      - id: "dotnet-sync-netcoreapp1.1"
+        display_name: "dotnet-sync-netcoreapp1.1"
+        variables:
+          ASYNC: "false"
+          FRAMEWORK: "netcoreapp1.1"
+      - id: "dotnet-async-net452"
+        display_name: dotnet-async-net452
+        variables:
+          ASYNC: "true"
+          FRAMEWORK: "net452"
+      - id: "dotnet-sync-net452"
+        display_name: dotnet-sync-452
+        variables:
+          ASYNC: "false"
+          FRAMEWORK: "net452"
 
 buildvariants:
 - matrix_name: "tests-python"
@@ -245,6 +288,20 @@ buildvariants:
     driver: ["ruby-master"]
     platform: ubuntu-18.04
     runtime: python38
+  display_name: "${driver} ${platform} ${runtime}"
+  tasks:
+    - ".all"
+- matrix_name: "tests-dotnet-windows"
+  matrix_spec:
+    driver: ["dotnet-csharp2515"]
+    platform: ["windows-64"]
+    runtime:
+      - "dotnet-async-netcoreapp2.1"
+      - "dotnet-sync-netcoreapp2.1"
+      - "dotnet-async-netcoreapp1.1"
+      - "dotnet-sync-netcoreapp1.1"
+      - "dotnet-async-net452"
+      - "dotnet-sync-net452"
   display_name: "${driver} ${platform} ${runtime}"
   tasks:
     - ".all"

--- a/integrations/dotnet/install-driver.sh
+++ b/integrations/dotnet/install-driver.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+set -o xtrace   # Write all commands first to stderr
+set -o errexit  # Exit the script with error if any of the commands fail
+
+# Environment variables used as input:
+#   FRAMEWORK                       Set to specify .NET framework to test against. Values: "net452", "netcoreapp1.1",
+#                                   "netcoreapp2.1"
+
+dotnet --version
+dotnet --list-sdks
+
+# /p required to get around https://github.com/dotnet/sdk/issues/12159
+dotnet build mongo-csharp-driver /p:Platform="Any CPU" # platform needs a space when building
+dotnet publish mongo-csharp-driver/tests/AstrolabeWorkloadExecutor \
+    --no-build --no-restore \
+    --framework "${FRAMEWORK}" \
+    /p:Platform="AnyCpu" # platform does not need a space when publishing

--- a/integrations/dotnet/workload-executor
+++ b/integrations/dotnet/workload-executor
@@ -1,0 +1,63 @@
+#!/usr/bin/env bash
+
+set -o xtrace   # Write all commands first to stderr
+set -o errexit  # Exit the script with error if any of the commands fail
+
+# Environment variables used as input:
+#   FRAMEWORK                       Set to specify .NET framework to test against. Values: "net452", "netcoreapp1.1",
+#                                   "netcoreapp2.1"
+#   ASYNC                           Whether or not to use async operations (which may be run synchronously). Values: true, false
+# Environment variables produced as output:
+#   RESULTS_DIR                     Where to output results.json
+#   ASYNC                           Whether or not to use async operations (which may be run synchronously). Values: true, false
+
+FRAMEWORK=${FRAMEWORK:-netcoreapp2.1}
+MAGIC_FILE_NAME=${MAGIC_FILE_NAME:-nox}
+ASYNC=${ASYNC:-true}
+############################################
+#            Functions                     #
+############################################
+
+
+############################################
+#            Main Program                  #
+############################################
+CONNECTION_STRING=$1
+WORKLOAD_SPEC=$2
+
+echo workload-executor pid: $BASHPID
+
+if [[ "$OS" =~ Windows|windows ]]; then
+  RESULTS_DIR=$(cygpath -w "$(pwd)")
+else
+  RESULTS_DIR="$(pwd)"
+fi
+
+# Set a trap for the INT
+# - wait for a state change in child process bearing ID $NATIVE_WORKLOAD_EXECUTOR_PID
+# - exit with the same status/code as the exit code of the call to wait (which returns the exit code of $NATIVE_WORKLOAD_EXECUTOR_PID)
+# Note that calls to wait return immediately if the child has already changed state
+
+trap 'echo You have activated my trap card; wait $NATIVE_WORKLOAD_EXECUTOR_PID; exit $?' INT
+
+export RESULTS_DIR
+export ASYNC
+
+PLATFORM="" # partial workaround for https://github.com/dotnet/sdk/issues/12159
+export PLATFORM
+
+# Invoke the workload executor as a background process and store its process ID as NATIVE_WORKLOAD_EXECUTOR_PID
+#     We don't need to build or restore because install-driver.sh handles that
+#     We can't use dotnet run --no-build --no-restore due to https://github.com/dotnet/runtime/issues/38274
+#     Addditionally, we must use the published version to bypass a dependency resolution issue with .NET Core 1.1
+if [[ "$FRAMEWORK" == "net452" ]]; then
+    ./mongo-csharp-driver/tests/AstrolabeWorkloadExecutor/bin/Debug/"${FRAMEWORK}"/publish/workload-executor.exe \
+        "${CONNECTION_STRING}" "${WORKLOAD_SPEC}" &
+else
+    dotnet mongo-csharp-driver/tests/AstrolabeWorkloadExecutor/bin/Debug/"${FRAMEWORK}"/publish/workload-executor.dll \
+        "${CONNECTION_STRING}" "${WORKLOAD_SPEC}" &
+fi
+export NATIVE_WORKLOAD_EXECUTOR_PID=$!
+
+# Wait for a state change in $NATIVE_WORKLOAD_EXECUTOR_PID (without this the foreground process would return)
+wait $NATIVE_WORKLOAD_EXECUTOR_PID


### PR DESCRIPTION
First cut at dotnet integration (race condition still extant)
https://spruce.mongodb.com/version/5ef3b7100ae6067429ce7311/tasks
Native workload executor PR: https://github.com/vincentkam/mongo-csharp-driver/pull/119
https://jira.mongodb.org/browse/CSHARP-2515
Edit: As noted in the jira ticket, we will be ignoring the race condition for now