### PR TITLE
Add Java driver workload executor

### DIFF
--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -187,6 +187,13 @@ axes:
           DRIVER_DIRNAME: "node"
           DRIVER_REPOSITORY: "https://github.com/mongodb/node-mongodb-native"
           DRIVER_REVISION: "master"
+      - id: java-master
+        display_name: "Java (master)"
+        variables:
+          DRIVER_DIRNAME: "java"
+          DRIVER_REPOSITORY: "https://github.com/mongodb/mongo-java-driver"
+          DRIVER_REVISION: "master"
+          ASTROLABE_EXECUTOR_STARTUP_TIME: 15
 
   # The 'platform' axis specifies the evergreen host distro to use.
   # Platforms MUST specify the PYTHON3_BINARY variable as this is required to install astrolabe.
@@ -278,3 +285,11 @@ buildvariants:
   display_name: "${driver} ${platform} ${runtime}"
   tasks:
     - .all
+
+- matrix_name: "tests-java"
+  matrix_spec:
+    driver: ["java-master"]
+    platform: ["ubuntu-18.04"]
+  display_name: "${driver} ${platform}"
+  tasks:
+    - ".all"

--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -247,6 +247,10 @@ axes:
         display_name: Node v12 Erbium
         variables:
           NODE_LTS_NAME: "erbium"
+      - id: java11
+        display_name: Java 11
+        variables:
+          JAVA_HOME: "/opt/java/jdk11"
 
 buildvariants:
 - matrix_name: "tests-python"
@@ -290,6 +294,7 @@ buildvariants:
   matrix_spec:
     driver: ["java-master"]
     platform: ["ubuntu-18.04"]
-  display_name: "${driver} ${platform}"
+    runtime: ["java11"]
+  display_name: "${driver} ${platform} ${runtime}"
   tasks:
     - ".all"

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,5 @@
 astrolabe.egg-info/
 results.json
 xunit-output/
+*~
+*.iml

--- a/integrations/java/install-driver.sh
+++ b/integrations/java/install-driver.sh
@@ -2,8 +2,6 @@
 
 set -o errexit
 
-export JAVA_HOME="/opt/java/jdk11"
-
 cd mongo-java-driver || exit
 
 ./gradlew --info driver-workload-executor:compileJava

--- a/integrations/java/install-driver.sh
+++ b/integrations/java/install-driver.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+set -o errexit
+
+export JAVA_HOME="/opt/java/jdk11"
+
+cd mongo-java-driver || exit
+
+./gradlew --info driver-workload-executor:compileJava

--- a/integrations/java/workload-executor
+++ b/integrations/java/workload-executor
@@ -2,8 +2,6 @@
 
 set -o errexit
 
-export JAVA_HOME="/opt/java/jdk11"
-
 OUTPUT_DIRECTORY=$PWD
 
 cd mongo-java-driver || exit

--- a/integrations/java/workload-executor
+++ b/integrations/java/workload-executor
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+set -o errexit
+
+export JAVA_HOME="/opt/java/jdk11"
+
+OUTPUT_DIRECTORY=$PWD
+
+cd mongo-java-driver || exit
+
+./gradlew --info  -Dorg.mongodb.workload.output.directory="$OUTPUT_DIRECTORY" -Dorg.mongodb.test.uri="$1" -Dorg.mongodb.workload.spec="$2" driver-workload-executor:run


### PR DESCRIPTION
* Add install script
* Add workload executor script
* Add Evergreen configuration

See https://jira.mongodb.org/browse/JAVA-3201 for a link to the mongo-java-driver repository commit on which this depends

Patch build: https://spruce.mongodb.com/version/5f2c5b8e32f41766c440b72c/tasks

Note that the validate-workload-executor task fails due to https://github.com/mongodb-labs/drivers-atlas-testing/issues/82