### PR TITLE
Overhaul configuration option definition and management

### DIFF
--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -75,7 +75,7 @@ functions:
         working_dir: astrolabe-src
         env:
           ATLAS_PROJECT_NAME: ${project}
-          EVERGREEN_BUILD_ID: ${build_id}
+          CLUSTER_NAME_SALT: ${build_id}
           ATLAS_API_USERNAME: ${atlas_key}
           ATLAS_API_PASSWORD: ${atlas_secret}
           ATLAS_API_BASE_URL: ${atlas_url}
@@ -107,7 +107,7 @@ functions:
         working_dir: astrolabe-src
         env:
           ATLAS_PROJECT_NAME: ${project}
-          EVERGREEN_BUILD_ID: ${build_id}
+          CLUSTER_NAME_SALT: ${build_id}
           ATLAS_API_USERNAME: ${atlas_key}
           ATLAS_API_PASSWORD: ${atlas_secret}
           ATLAS_API_BASE_URL: ${atlas_url}

--- a/astrolabe/cli.py
+++ b/astrolabe/cli.py
@@ -22,69 +22,46 @@ import click
 import astrolabe.commands as cmd
 import astrolabe.docgen as docgen
 from atlasclient import AtlasClient, AtlasApiBaseError
-from atlasclient.configuration import CONFIG_DEFAULTS as CL_DEFAULTS
 from astrolabe.docgen import (
     tabulate_astrolabe_configuration, tabulate_client_configuration)
 from astrolabe.runner import MultiTestRunner, SingleTestRunner
 from astrolabe.configuration import (
-    CLI_OPTION_NAMES as OPTNAMES,
-    CONFIG_DEFAULTS as DEFAULTS,
-    CONFIG_ENVVARS as ENVVARS,
-    TestCaseConfiguration)
+    CONFIGURATION_OPTIONS as CONFIGOPTS, TestCaseConfiguration)
 from astrolabe.utils import (
-    get_cluster_name, get_test_name_from_spec_file, ClickLogHandler)
+    create_click_option, get_cluster_name, get_test_name_from_spec_file,
+    ClickLogHandler)
 from astrolabe.validator import validator_factory
 
 
 LOGGER = logging.getLogger(__name__)
 
+DBUSERNAME_OPTION = create_click_option(CONFIGOPTS.ATLAS_DB_USERNAME)
 
-# Define CLI options used in multiple commands for easy re-use.
-DBUSERNAME_OPTION = click.option(
-    OPTNAMES.DB_USERNAME, type=click.STRING, default=DEFAULTS.DB_USERNAME,
-    show_default=True, help='Database username on the MongoDB instance.')
+DBPASSWORD_OPTION = create_click_option(CONFIGOPTS.ATLAS_DB_PASSWORD)
 
-DBPASSWORD_OPTION = click.option(
-    OPTNAMES.DB_PASSWORD, type=click.STRING, default=DEFAULTS.DB_PASSWORD,
-    show_default=True, help='Database password on the MongoDB instance.')
+ATLASORGANIZATIONNAME_OPTION = create_click_option(
+    CONFIGOPTS.ATLAS_ORGANIZATION_NAME)
 
-ATLASORGANIZATIONNAME_OPTION = click.option(
-    OPTNAMES.ORGANIZATION_NAME, type=click.STRING,
-    envvar=ENVVARS.ORGANIZATION_NAME, default=DEFAULTS.ORGANIZATION_NAME,
-    show_default=True, help='Name of the Atlas Organization.')
+ATLASPROJECTNAME_OPTION = create_click_option(CONFIGOPTS.ATLAS_PROJECT_NAME)
+
+POLLINGTIMEOUT_OPTION = create_click_option(CONFIGOPTS.ATLAS_POLLING_TIMEOUT)
+
+POLLINGFREQUENCY_OPTION = create_click_option(
+    CONFIGOPTS.ATLAS_POLLING_FREQUENCY)
+
+EXECUTORSTARTUPTIME_OPTION = create_click_option(
+    CONFIGOPTS.ASTROLABE_EXECUTOR_STARTUP_TIME)
+
+CLUSTERNAMESALT_OPTION = create_click_option(CONFIGOPTS.CLUSTER_NAME_SALT)
 
 ATLASCLUSTERNAME_OPTION = click.option(
     '--cluster-name', required=True, type=click.STRING,
     help='Name of the Atlas Cluster.')
 
-ATLASPROJECTNAME_OPTION = click.option(
-    OPTNAMES.PROJECT_NAME, required=True, type=click.STRING,
-    envvar=ENVVARS.PROJECT_NAME, help='Name of the Atlas Project.')
-
-POLLINGTIMEOUT_OPTION = click.option(
-    OPTNAMES.POLLING_TIMEOUT, type=click.FLOAT, show_default=True,
-    envvar=ENVVARS.POLLING_TIMEOUT, default=DEFAULTS.POLLING_TIMEOUT,
-    help="Maximum time (in s) to poll API endpoints.")
-
-POLLINGFREQUENCY_OPTION = click.option(
-    OPTNAMES.POLLING_FREQUENCY, type=click.FLOAT, show_default=True,
-    envvar=ENVVARS.POLLING_FREQUENCY, default=DEFAULTS.POLLING_FREQUENCY,
-    help='Frequency (in Hz) at which to poll API endpoints.')
-
 WORKLOADEXECUTOR_OPTION = click.option(
     '-e', '--workload-executor', required=True, type=click.Path(
         exists=True, file_okay=True, dir_okay=False, resolve_path=True),
     help='Absolute or relative path to the workload-executor.')
-
-EXECUTORSTARTUPTIME_OPTION = click.option(
-    OPTNAMES.EXECUTOR_STARTUP_TIME, default=1, type=click.FLOAT,
-    show_default=True, envvar=ENVVARS.EXECUTOR_STARTUP_TIME,
-    help='Time (in s) to wait for the executor to start running.')
-
-CLUSTERNAMESALT_OPTION = click.option(
-    OPTNAMES.CLUSTER_NAME_SALT, type=click.STRING, required=True,
-    envvar=ENVVARS.CLUSTER_NAME_SALT,
-    help='Salt for generating unique hashes.')
 
 XUNITOUTPUT_OPTION = click.option(
     '--xunit-output', type=click.STRING, default="xunit-output",
@@ -99,24 +76,11 @@ NODELETE_FLAG = click.option(
 
 
 @click.group()
-@click.option(OPTNAMES.BASE_URL, envvar=ENVVARS.BASE_URL,
-              default=CL_DEFAULTS.BASE_URL, show_default=True,
-              type=click.STRING, help='Base URL of the Atlas API.')
-@click.option('-u', '--atlas-api-username', default=None,
-              envvar=ENVVARS.API_USERNAME, type=click.STRING,
-              help='HTTP-Digest username (Atlas API public-key).')
-@click.option('-p', '--atlas-api-password', default=None,
-              envvar=ENVVARS.API_PASSWORD, type=click.STRING,
-              help='HTTP-Digest password (Atlas API private-key).')
-@click.option(OPTNAMES.HTTP_TIMEOUT, envvar=ENVVARS.HTTP_TIMEOUT,
-              default=CL_DEFAULTS.HTTP_TIMEOUT, type=click.FLOAT,
-              show_default=True,
-              help='Time (in s) after which HTTP requests should timeout.')
-@click.option('-v', OPTNAMES.LOG_VERBOSITY, envvar=ENVVARS.LOG_VERBOSITY,
-              type=click.Choice(
-                  ['DEBUG', 'INFO', 'WARNING', 'ERROR', 'CRITICAL'],
-                  case_sensitive=False), default=DEFAULTS.LOG_VERBOSITY,
-              show_default=True, help='Set the logging level.')
+@create_click_option(CONFIGOPTS.ATLAS_API_BASE_URL)
+@create_click_option(CONFIGOPTS.ATLAS_API_USERNAME)
+@create_click_option(CONFIGOPTS.ATLAS_API_PASSWORD)
+@create_click_option(CONFIGOPTS.ATLAS_HTTP_TIMEOUT)
+@create_click_option(CONFIGOPTS.ASTROLABE_LOGLEVEL)
 @click.version_option()
 @click.pass_context
 def cli(ctx, atlas_base_url, atlas_api_username,

--- a/astrolabe/cli.py
+++ b/astrolabe/cli.py
@@ -20,10 +20,10 @@ from urllib.parse import unquote_plus
 import click
 
 import astrolabe.commands as cmd
-import astrolabe.docgen as docgen
 from atlasclient import AtlasClient, AtlasApiBaseError
 from astrolabe.docgen import (
-    tabulate_astrolabe_configuration, tabulate_client_configuration)
+    generate_configuration_help, tabulate_astrolabe_configuration,
+    tabulate_client_configuration)
 from astrolabe.runner import MultiTestRunner, SingleTestRunner
 from astrolabe.configuration import (
     CONFIGURATION_OPTIONS as CONFIGOPTS, TestCaseConfiguration)
@@ -339,16 +339,10 @@ def help_topics():
     pass
 
 
-@help_topics.command('environment-variables')
-def help_environment_variables():
-    """About configuring astrolabe via environment variables."""
-    click.echo_via_pager(docgen.generate_environment_variables_help())
-
-
-@help_topics.command('default-values')
-def help_default_values():
-    """About default values of configuration options."""
-    click.echo_via_pager(docgen.generate_default_value_help())
+@help_topics.command('configuration')
+def help_configuration_options():
+    """About astrolabe's configurable settings."""
+    click.echo_via_pager(generate_configuration_help())
 
 
 @cli.group('spec-tests')

--- a/astrolabe/configuration.py
+++ b/astrolabe/configuration.py
@@ -14,47 +14,83 @@
 
 from collections import namedtuple
 
+import click
+
+from atlasclient.configuration import CONFIG_DEFAULTS as CL_DEFAULTS
 from atlasclient.utils import JSONObject
 
-CONFIG_DEFAULTS = JSONObject.from_dict({
-    "ORGANIZATION_NAME": "MongoDB Drivers Team",
-    "DB_USERNAME": "atlasuser",
-    "DB_PASSWORD": "mypassword123",
-    "POLLING_TIMEOUT": 1200.0,
-    "POLLING_FREQUENCY": 1.0,
-    "LOG_VERBOSITY": "INFO"
-})
 
-
-CONFIG_ENVVARS = JSONObject.from_dict({
-    "ORGANIZATION_NAME": "ATLAS_ORGANIZATION_NAME",
-    "PROJECT_NAME": "ATLAS_PROJECT_NAME",         # ${project} in EVG
-    "CLUSTER_NAME_SALT": "EVERGREEN_BUILD_ID",      # ${build_id} in EVG
-    "POLLING_TIMEOUT": "ATLAS_POLLING_TIMEOUT",
-    "POLLING_FREQUENCY": "ATLAS_POLLING_FREQUENCY",
-    "BASE_URL": "ATLAS_API_BASE_URL",
-    "API_USERNAME": "ATLAS_API_USERNAME",
-    "API_PASSWORD": "ATLAS_API_PASSWORD",
-    "HTTP_TIMEOUT": "ATLAS_HTTP_TIMEOUT",
-    "LOG_VERBOSITY": "ASTROLABE_LOGLEVEL",
-    "EXECUTOR_STARTUP_TIME": "ASTROLABE_EXECUTOR_STARTUP_TIME"
-})
-
-
-CLI_OPTION_NAMES = JSONObject.from_dict({
-    "PROJECT_NAME": "--project-name",
-    "CLUSTER_NAME_SALT": "--cluster-name-salt",
-    "POLLING_TIMEOUT": "--polling-timeout",
-    "POLLING_FREQUENCY": "--polling-frequency",
-    "API_USERNAME": "--atlas-api-username",
-    "API_PASSWORD": "--atlas-api-password",
-    "DB_USERNAME": "--db-username",
-    "DB_PASSWORD": "--db-password",
-    "ORGANIZATION_NAME": "--org-name",
-    "BASE_URL": "--atlas-base-url",
-    "HTTP_TIMEOUT": "--http-timeout",
-    "LOG_VERBOSITY": "--log-level",
-    "EXECUTOR_STARTUP_TIME": "--startup-time"
+# Mapping used to generate configurable options for Astrolabe.
+# See astrolabe.utils.create_click_option for details.
+CONFIGURATION_OPTIONS = JSONObject({
+    'ATLAS_PROJECT_NAME': {         # ${project} in EVG
+        'help': 'Name of the Atlas Project.',
+        'cliopt': '--project-name',
+        'envvar': 'ATLAS_PROJECT_NAME'},
+    'CLUSTER_NAME_SALT': {          # ${build_id} in EVG
+        'help': 'Salt for generating unique hashes.',
+        'cliopt': '--cluster-name-salt',
+        'envvar': 'CLUSTER_NAME_SALT'},
+    'ATLAS_POLLING_TIMEOUT': {
+        'type': click.FLOAT,
+        'help': 'Maximum time (in s) to poll API endpoints.',
+        'cliopt': '--polling-timeout',
+        'envvar': 'ATLAS_POLLING_TIMEOUT',
+        'default': 1200.0},
+    'ATLAS_POLLING_FREQUENCY': {
+        'type': click.FLOAT,
+        'help': 'Frequency (in Hz) at which to poll API endpoints.',
+        'cliopt': '--polling-frequency',
+        'envvar': 'ATLAS_POLLING_FREQUENCY',
+        'default': 1.0},
+    'ATLAS_API_USERNAME': {
+        'help': 'HTTP-Digest username (Atlas API public-key).',
+        'cliopt': '--atlas-api-username',
+        'envvar': 'ATLAS_API_USERNAME',
+        'default': None},
+    'ATLAS_API_PASSWORD': {
+        'help': 'HTTP-Digest password (Atlas API private-key).',
+        'cliopt': '--atlas-api-password',
+        'envvar': 'ATLAS_API_PASSWORD',
+        'default': None},
+    'ATLAS_DB_USERNAME': {
+        'help': 'Database username on the MongoDB instance.',
+        'cliopt': '--db-username',
+        'default': 'atlasuser',},
+    'ATLAS_DB_PASSWORD': {
+        'help': 'Database password on the MongoDB instance.',
+        'cliopt': '--db-password',
+        'default': 'mypassword123'},
+    'ATLAS_ORGANIZATION_NAME': {
+        'help': 'Name of the Atlas Organization.',
+        'cliopt': '--org-name',
+        'envvar': 'ATLAS_ORGANIZATION_NAME',
+        'default': 'MongoDB Drivers Team'},
+    'ATLAS_API_BASE_URL': {
+        'help': 'Base URL of the Atlas API.',
+        'cliopt': '--atlas-base-url',
+        'envvar': 'ATLAS_API_BASE_URL',
+        'default': CL_DEFAULTS.ATLAS_API_BASE_URL},
+    'ATLAS_HTTP_TIMEOUT': {
+        'type': click.FLOAT,
+        'help': 'Time (in s) after which HTTP requests should timeout.',
+        'cliopt': '--http-timeout',
+        'envvar': 'ATLAS_HTTP_TIMEOUT',
+        'default': CL_DEFAULTS.ATLAS_HTTP_TIMEOUT},
+    'ASTROLABE_LOGLEVEL': {
+        'type': click.Choice(
+            ['DEBUG', 'INFO', 'WARNING', 'ERROR', 'CRITICAL'],
+            case_sensitive=False),
+        'help': 'Set the logging level.',
+        'cliopt': ('-v', '--log-level'),
+        'envvar': 'ASTROLABE_LOGLEVEL',
+        'default': 'INFO'},
+    'ASTROLABE_EXECUTOR_STARTUP_TIME': {
+        'type': click.FLOAT,
+        'help': 'Time (in s) to wait for the executor to start running.',
+        'cliopt': '--startup-time',
+        'envvar': 'ASTROLABE_EXECUTOR_STARTUP_TIME',
+        'default': 1.0}
 })
 
 

--- a/astrolabe/docgen.py
+++ b/astrolabe/docgen.py
@@ -12,42 +12,28 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from itertools import chain
 from textwrap import dedent
 
 from tabulate import tabulate
 
-from astrolabe.configuration import (
-    CONFIG_ENVVARS as ENVVARS,
-    CONFIG_DEFAULTS as DEFAULTS,
-    CLI_OPTION_NAMES as OPTNAMES)
-from atlasclient.configuration import CONFIG_DEFAULTS as CL_DEFAULTS
+from astrolabe.configuration import CONFIGURATION_OPTIONS as CONFIGOPTS
 
 
-def generate_environment_variables_help():
+def generate_configuration_help():
     text = dedent("""\
-    Many of Astrolabe's configuration options can be set at runtime using
-    environment variables. The following table lists configurable options
-    and the corresponding environment variables that can used to set them:
+    Astrolabe has many configurable options that can be set at runtime via the command-line, or using environment variables. The following table 
+    lists these configurable options, their default values, and the environment variables that can be used to specify them. 
+    Note that if an option is specified using an environment variable, and also via the command-line, the command-line value takes precedence.
     {}""")
     tabledata = []
-    for internal_id, envvar_name in ENVVARS.items():
-        tabledata.append([internal_id, OPTNAMES[internal_id], envvar_name])
-    headers = ["Internal ID", "CLI Option Name",
-               "Environment Variable"]
-    tabletext = tabulate(tabledata, headers=headers, tablefmt="rst")
-    return text.format(tabletext)
-
-
-def generate_default_value_help():
-    text = "Default values of Astrolabe's configuration options are:\n{}"
-    tabledata = []
-    for internal_id, default_value in chain(
-            CL_DEFAULTS.items(), DEFAULTS.items()):
-        if internal_id in OPTNAMES:
-            tabledata.append(
-                [internal_id, OPTNAMES[internal_id], default_value])
-    headers = ["Internal ID", "CLI Option Name", "Default Value"]
+    headers = ["CLI Option", "Environment Variable", "Default", "Description"]
+    for _, optspec in CONFIGOPTS.items():
+        cliopt_string = optspec['cliopt']
+        if isinstance(cliopt_string, tuple):
+            cliopt_string = '/'.join(cliopt_string)
+        tabledata.append([
+            cliopt_string, optspec.get('envvar', '-'),
+            str(optspec.get('default', '-')), optspec['help']])
     tabletext = tabulate(tabledata, headers=headers, tablefmt="rst")
     return text.format(tabletext)
 

--- a/astrolabe/utils.py
+++ b/astrolabe/utils.py
@@ -45,6 +45,41 @@ class ClickLogHandler(logging.Handler):
             self.handleError(record)
 
 
+def create_click_option(option_spec, **kwargs):
+    """Utility that creates a click option decorator from an `option_spec`
+    mapping. Optionally, the user can pass `**kwargs` which are passed
+    directly to the click.option constructor. The `option_spec` mapping
+    has the following keys:
+
+      - help (required): help-text for this option
+      - cliopt (required): command-line parameter name for this option; can
+        be a tuple to specify short and long-form names for an option
+      - envvar (optional): environment variable name for this option; option
+        values cannot be specified using an environment variable by default
+      - type (optional): click type to use for validating the user-input value
+        for this option; defaults to click.STRING
+      - default (optional): default value for this option; if provided, this
+        will be displayed in the help text unless `show_default=False` is
+        passed in the `**kwargs`; if not provided, the option will be
+        assumed to be `required=True`
+    """
+    click_kwargs = {
+        'type': option_spec.get('type', click.STRING),
+        'help': option_spec['help']}
+    if 'envvar' in option_spec:
+        kwargs['envvar'] = option_spec['envvar']
+    if 'default' in option_spec:
+        kwargs['default'] = option_spec['default']
+        kwargs['show_default'] = True
+    else:
+        kwargs['required'] = True
+
+    click_kwargs.update(kwargs)
+    if isinstance(option_spec['cliopt'], tuple):
+        return click.option(*option_spec['cliopt'], **click_kwargs)
+    return click.option(option_spec['cliopt'], **click_kwargs)
+
+
 def assert_subset(dict1, dict2):
     """Utility that asserts that `dict2` is a subset of `dict1`, while
     accounting for nested fields."""

--- a/atlasclient/client.py
+++ b/atlasclient/client.py
@@ -92,9 +92,9 @@ class _ApiResponse:
 class AtlasClient:
     """An easy-to-use MongoDB Atlas API client for Python. """
     def __init__(self, *, username, password,
-                 base_url=DEFAULTS.BASE_URL,
-                 api_version=DEFAULTS.API_VERSION,
-                 timeout=DEFAULTS.HTTP_TIMEOUT):
+                 base_url=DEFAULTS.ATLAS_API_BASE_URL,
+                 api_version=DEFAULTS.ATLAS_API_VERSION,
+                 timeout=DEFAULTS.ATLAS_HTTP_TIMEOUT):
         """
         Client for the `MongoDB Atlas API
         <https://docs.atlas.mongodb.com/api/>`_.

--- a/atlasclient/configuration.py
+++ b/atlasclient/configuration.py
@@ -26,6 +26,6 @@ ClientConfiguration = namedtuple(
 
 # Default configuration values.
 CONFIG_DEFAULTS = JSONObject.from_dict({
-    "HTTP_TIMEOUT": 10.0,
-    "API_VERSION": 1.0,
-    "BASE_URL": "https://cloud.mongodb.com/api/atlas"})
+    "ATLAS_HTTP_TIMEOUT": 10.0,
+    "ATLAS_API_VERSION": 1.0,
+    "ATLAS_API_BASE_URL": "https://cloud.mongodb.com/api/atlas"})


### PR DESCRIPTION
Closes #23 

With this change, the `astrolabe info default-values` and `astrolabe info environment-variables` help commands are both replaced with `astrolabe info configuration`. Output:

```
Astrolabe has many configurable options that can be set at runtime via the command-line, or using environment variables. The following table 
lists these configurable options, their default values, and the environment variables that can be used to specify them. 
Note that if an option is specified using an environment variable, and also via the command-line, the command-line value takes precedence.
====================  ===============================  ===================================  ======================================================
CLI Option            Environment Variable             Default                              Description
====================  ===============================  ===================================  ======================================================
--project-name        ATLAS_PROJECT_NAME               -                                    Name of the Atlas Project.
--cluster-name-salt   CLUSTER_NAME_SALT                -                                    Salt for generating unique hashes.
--polling-timeout     ATLAS_POLLING_TIMEOUT            1200.0                               Maximum time (in s) to poll API endpoints.
--polling-frequency   ATLAS_POLLING_FREQUENCY          1.0                                  Frequency (in Hz) at which to poll API endpoints.
--atlas-api-username  ATLAS_API_USERNAME               None                                 HTTP-Digest username (Atlas API public-key).
--atlas-api-password  ATLAS_API_PASSWORD               None                                 HTTP-Digest password (Atlas API private-key).
--db-username         -                                atlasuser                            Database username on the MongoDB instance.
--db-password         -                                mypassword123                        Database password on the MongoDB instance.
--org-name            ATLAS_ORGANIZATION_NAME          MongoDB Drivers Team                 Name of the Atlas Organization.
--atlas-base-url      ATLAS_API_BASE_URL               https://cloud.mongodb.com/api/atlas  Base URL of the Atlas API.
--http-timeout        ATLAS_HTTP_TIMEOUT               10.0                                 Time (in s) after which HTTP requests should timeout.
-v/--log-level        ASTROLABE_LOGLEVEL               INFO                                 Set the logging level.
--startup-time        ASTROLABE_EXECUTOR_STARTUP_TIME  1.0                                  Time (in s) to wait for the executor to start running.
====================  ===============================  ===================================  ======================================================
```
