### PR TITLE
Make API version configurable when issuing a request

### DIFF
--- a/atlasclient/client.py
+++ b/atlasclient/client.py
@@ -187,7 +187,8 @@ class AtlasClient:
             a server to the IP Whitelist, a list of documents must be sent).
         """
         method = method.upper()
-        url = self.construct_resource_url(path)
+        url = self.construct_resource_url(
+            path, api_version=params.pop('api_version', None))
 
         query_params = {}
         for param_name in ("pretty", "envelope", "itemsPerPage", "pageNum"):
@@ -217,11 +218,12 @@ class AtlasClient:
 
         return self.handle_response(method, response)
 
-    def construct_resource_url(self, path):
-        url_template = "{base_url}/v{version}/{resource_path}"
-        return url_template.format(base_url=self.config.base_url,
-                                   version=self.config.api_version,
-                                   resource_path=path)
+    def construct_resource_url(self, path, api_version=None):
+        url_template = "{base_url}/{version}/{resource_path}"
+        return url_template.format(
+            base_url=self.config.base_url,
+            version=api_version or self.config.api_version,
+            resource_path=path)
 
     @staticmethod
     def handle_response(method, response):

--- a/atlasclient/configuration.py
+++ b/atlasclient/configuration.py
@@ -27,5 +27,5 @@ ClientConfiguration = namedtuple(
 # Default configuration values.
 CONFIG_DEFAULTS = JSONObject.from_dict({
     "ATLAS_HTTP_TIMEOUT": 10.0,
-    "ATLAS_API_VERSION": 1.0,
+    "ATLAS_API_VERSION": "v1.0",
     "ATLAS_API_BASE_URL": "https://cloud.mongodb.com/api/atlas"})


### PR DESCRIPTION
This change allows us to specify the `apiVersion` portion of an Atlas API call at invocation (currently this is a configurable value but it can only be specified upon client initialization, not when issuing a request). The full URL generated is `<baseUrl>/<apiVersion>/<resourcePath>`.

To issue a command to the `private` API version, for example to retrieve logs, a user can now do:

```
client = AtlasClient(username=<username>, password=<password>)
response = client.nds.groups.project_id.clusters.cluster_name.get(api_version='private').data
```