### PR TITLE
 DRIVERS-828 add tests for uncaptured errors and failures

### DIFF
--- a/astrolabe/exceptions.py
+++ b/astrolabe/exceptions.py
@@ -26,3 +26,7 @@ class PollingTimeoutError(AstrolabeBaseError):
 
 class WorkloadExecutorError(AstrolabeBaseError):
     pass
+
+
+class PrematureExitError(WorkloadExecutorError):
+    pass

--- a/astrolabe/runner.py
+++ b/astrolabe/runner.py
@@ -234,7 +234,7 @@ class AtlasTestCase:
         sleep(10)
         
         # Step-5: interrupt driver workload and capture streams
-        stats = self.workload_runner.terminate()
+        stats = self.workload_runner.stop()
 
         # Stop the timer
         timer.stop()

--- a/astrolabe/utils.py
+++ b/astrolabe/utils.py
@@ -243,7 +243,9 @@ class DriverWorkloadSubprocessRunner:
 
         return self.workload_subprocess
 
-    def terminate(self):
+    def stop(self):
+        '''Stop the process, verifying it didn't already exit.'''
+        
         LOGGER.info("Stopping workload executor [PID: {}]".format(self.pid))
 
         if not self.is_windows:
@@ -266,7 +268,41 @@ class DriverWorkloadSubprocessRunner:
         # terminated earlier than they actually terminate on Windows.
         if self.is_windows:
             sleep(2)
+            
+        return self.read_stats()
+        
+    def terminate(self):
+        '''Ensure the process is terminated.'''
+        
+        LOGGER.info("Stopping workload executor [PID: {}]".format(self.pid))
 
+        try:
+            if not self.is_windows:
+                os.killpg(self.workload_subprocess.pid, signal.SIGINT)
+            else:
+                os.kill(self.workload_subprocess.pid, signal.CTRL_BREAK_EVENT)
+        except:
+            pass
+
+        # Since the default server selection timeout is 30 seconds,
+        # allow up to 60 seconds for the workload executor to terminate.
+        t_wait = 60
+        try:
+            self.workload_subprocess.wait(timeout=t_wait)
+            LOGGER.info("Stopped workload executor [PID: {}]".format(self.pid))
+        except subprocess.TimeoutExpired:
+            raise WorkloadExecutorError(
+                "The workload executor did not terminate {} seconds "
+                "after sending the termination signal".format(t_wait))
+
+        # Workload executors wrapped in shell scripts can report that they've
+        # terminated earlier than they actually terminate on Windows.
+        if self.is_windows:
+            sleep(2)
+            
+        return self.read_stats()
+        
+    def read_stats(self):
         try:
             LOGGER.info("Reading sentinel file {!r}".format(self.sentinel))
             with open(self.sentinel, 'r') as fp:

--- a/astrolabe/validator.py
+++ b/astrolabe/validator.py
@@ -245,6 +245,21 @@ class ValidateWorkloadExecutor(TestCase):
                 "to be reported, got {} instead.".format(
                     num_reported_finds, stats['numIterations']))
 
+    def test_num_failures_not_captured(self):
+        driver_workload = JSONObject.from_dict(
+            yaml.safe_load(open('tests/validator-numFailures-not-captured.yml').read())['driverWorkload']
+        )
+
+        stats = self.run_test_expecting_error(driver_workload)
+
+        num_reported_errors = stats['numFailures']
+        if num_reported_errors != -1:
+            self.fail(
+                "The workload executor reported unexpected execution "
+                "statistics. Expected -1 failures since failures were not captured, "
+                "got {} instead.".format(
+                    num_reported_errors))
+
     def test_num_failures_as_errors(self):
         driver_workload = JSONObject.from_dict(
             yaml.safe_load(open('tests/validator-numFailures-as-errors.yml').read())['driverWorkload']

--- a/astrolabe/validator.py
+++ b/astrolabe/validator.py
@@ -96,15 +96,15 @@ class ValidateWorkloadExecutor(TestCase):
 
         stats = self.run_test(driver_workload)
 
-        num_reported_updates = stats['numSuccesses']
+        num_successes = stats['numSuccesses']
         update_count = self.coll.find_one(
             {'_id': 'validation_sentinel'})['count']
-        if abs(num_reported_updates - update_count) > 1:
+        if abs(num_successes/2 - update_count) > 1:
             self.fail(
                 "The workload executor reported inconsistent execution "
-                "statistics. Expected {} successful "
-                "updates to be reported, got {} instead.".format(
-                    update_count, num_reported_updates))
+                "statistics. Expected 2*{} successful "
+                "operations to be reported, got {} instead.".format(
+                    update_count, num_successes))
         if abs(stats['numIterations'] - update_count) > 1:
             self.fail(
                 "The workload executor reported inconsistent execution "
@@ -155,23 +155,23 @@ class ValidateWorkloadExecutor(TestCase):
 
         stats = self.run_test(driver_workload)
 
-        num_reported_updates = stats['numSuccesses']
+        num_successes = stats['numSuccesses']
         update_count = self.coll.find_one(
             {'_id': 'validation_sentinel'})['count']
-        if abs(num_reported_updates - update_count) > 1:
+        if abs(num_successes/2 - update_count) > 1:
             self.fail(
                 "The workload executor reported inconsistent execution "
-                "statistics. Expected {} successful "
-                "updates to be reported, got {} instead.".format(
-                    update_count, num_reported_updates))
+                "statistics. Expected 2*{} successful "
+                "operations to be reported, got {} instead.".format(
+                    update_count, num_successes))
 
         num_reported_errors = stats['numErrors']
-        if abs(num_reported_errors - num_reported_updates) > 1:
+        if abs(num_reported_errors - num_successes/2) > 1:
             self.fail(
                 "The workload executor reported inconsistent execution "
-                "statistics. Expected approximately {} errored operations "
+                "statistics. Expected approximately {}/2 errored operations "
                 "to be reported, got {} instead.".format(
-                    num_reported_updates, num_reported_errors))
+                    num_successes, num_reported_errors))
         if abs(stats['numIterations'] - update_count) > 1:
             self.fail(
                 "The workload executor reported inconsistent execution "
@@ -189,13 +189,13 @@ class ValidateWorkloadExecutor(TestCase):
         num_reported_finds = stats['numSuccesses']
 
         num_reported_failures = stats['numFailures']
-        if abs(num_reported_failures - num_reported_finds) > 1:
+        if abs(num_reported_failures - num_reported_finds/2) > 1:
             self.fail(
                 "The workload executor reported inconsistent execution "
-                "statistics. Expected approximately {} errored operations "
+                "statistics. Expected approximately {}/2 errored operations "
                 "to be reported, got {} instead.".format(
                     num_reported_finds, num_reported_failures))
-        if abs(stats['numIterations'] - num_reported_finds) > 1:
+        if abs(stats['numIterations'] - num_reported_finds/2) > 1:
             self.fail(
                 "The workload executor reported inconsistent execution "
                 "statistics. Expected {} iterations "
@@ -213,10 +213,10 @@ class ValidateWorkloadExecutor(TestCase):
 
         num_reported_errors = stats['numErrors']
         num_reported_failures = stats['numFailures']
-        if abs(num_reported_errors - num_reported_finds) > 1:
+        if abs(num_reported_errors - num_reported_finds/2) > 1:
             self.fail(
                 "The workload executor reported inconsistent execution "
-                "statistics. Expected approximately {} errored operations "
+                "statistics. Expected approximately {}/2 errored operations "
                 "to be reported, got {} instead.".format(
                     num_reported_finds, num_reported_failures))
         if num_reported_failures > 0:
@@ -225,7 +225,7 @@ class ValidateWorkloadExecutor(TestCase):
                 "statistics. Expected all failures to be reported as errors, "
                 "got {} failures instead.".format(
                     num_reported_failures))
-        if abs(stats['numIterations'] - num_reported_finds) > 1:
+        if abs(stats['numIterations'] - num_reported_finds/2) > 1:
             self.fail(
                 "The workload executor reported inconsistent execution "
                 "statistics. Expected {} iterations "

--- a/astrolabe/validator.py
+++ b/astrolabe/validator.py
@@ -22,7 +22,7 @@ from pymongo import MongoClient
 import yaml
 
 from atlasclient import JSONObject
-from astrolabe.exceptions import WorkloadExecutorError
+from astrolabe.exceptions import WorkloadExecutorError, PrematureExitError
 from astrolabe.utils import DriverWorkloadSubprocessRunner
 
 
@@ -107,7 +107,11 @@ class ValidateWorkloadExecutor(TestCase):
             pass
 
         try:
-            stats = subprocess.terminate()
+            stats = subprocess.stop()
+        except PrematureExitError:
+            # OK for workload executor to exit prematurely when we expect
+            # it to fail with an error. We still need to return stats.
+            stats = subprocess.read_stats()
         except TimeoutExpired:
             self.fail("The workload executor did not terminate soon after "
                       "receiving the termination signal.")

--- a/tests/validator-numErrors-not-captured.yml
+++ b/tests/validator-numErrors-not-captured.yml
@@ -1,0 +1,56 @@
+# This file intentionally causes the workload executor to produce an error
+# on each execution.
+
+operations: []
+
+driverWorkload:
+  description: "Validator - num errors"
+
+  schemaVersion: "1.2"
+
+  createEntities:
+    - client:
+        id: &client0 client0
+    - database:
+        id: &database0 database0
+        client: *client0
+        databaseName: &database0Name dat
+    - collection:
+        id: &collection0 collection0
+        database: *database0
+        collectionName: &collection0Name dat
+
+  initialData:
+    - collectionName: *collection0Name
+      databaseName: *database0Name
+      documents:
+        -
+          _id: validation_sentinel
+          count: 0
+
+  tests:
+    - description: "updateOne & error"
+      operations:
+        - name: loop
+          object: testRunner
+          arguments:
+            storeIterationsAsEntity: iterations
+            storeSuccessesAsEntity: successes
+            operations:
+              # Reduce log spam
+              - name: find
+                object: *collection0
+                arguments:
+                  filter: { $where: 'sleep(250)' }
+              
+              - name: updateOne
+                object: *collection0
+                arguments:
+                  filter: { _id: validation_sentinel}
+                  update: 
+                    $inc:
+                      count: 1
+              - name: doesNotExist
+                object: *collection0
+                arguments:
+                  foo: bar

--- a/tests/validator-numErrors.yml
+++ b/tests/validator-numErrors.yml
@@ -38,6 +38,12 @@ driverWorkload:
             storeSuccessesAsEntity: successes
             storeErrorsAsEntity: errors
             operations:
+              # Reduce log spam
+              - name: find
+                object: *collection0
+                arguments:
+                  filter: { $where: 'sleep(250)' }
+              
               - name: updateOne
                 object: *collection0
                 arguments:

--- a/tests/validator-numFailures-as-errors.yml
+++ b/tests/validator-numFailures-as-errors.yml
@@ -38,6 +38,12 @@ driverWorkload:
             storeSuccessesAsEntity: successes
             storeErrorsAsEntity: errors
             operations:
+              # Reduce log spam
+              - name: find
+                object: *collection0
+                arguments:
+                  filter: { $where: 'sleep(250)' }
+              
               - name: find
                 object: *collection0
                 arguments:

--- a/tests/validator-numFailures-not-captured.yml
+++ b/tests/validator-numFailures-not-captured.yml
@@ -1,0 +1,63 @@
+# This file intentionally causes the workload executor to produce a failure
+# on each execution.
+
+operations: []
+
+driverWorkload:
+  description: "Validator - num failures"
+
+  schemaVersion: "1.2"
+
+  createEntities:
+    - client:
+        id: &client0 client0
+    - database:
+        id: &database0 database0
+        client: *client0
+        databaseName: &database0Name dat
+    - collection:
+        id: &collection0 collection0
+        database: *database0
+        collectionName: &collection0Name dat
+
+  initialData:
+    - collectionName: *collection0Name
+      databaseName: *database0Name
+      documents:
+        -
+          _id: 2
+          x: 2
+
+  tests:
+    - description: "Find one & failure"
+      operations:
+        - name: loop
+          object: testRunner
+          arguments:
+            storeIterationsAsEntity: iterations
+            storeSuccessesAsEntity: successes
+            operations:
+              # Reduce log spam
+              - name: find
+                object: *collection0
+                arguments:
+                  filter: { $where: 'sleep(250)' }
+              
+              - name: find
+                object: *collection0
+                arguments:
+                  filter: { _id: { $gt: 1 }}
+                  sort: { _id: 1 }
+                expectResult:
+                  -
+                    _id: 2
+                    x: 2
+              - name: find
+                object: *collection0
+                arguments:
+                  filter: { _id: { $gt: 1 }}
+                  sort: { _id: 1 }
+                expectResult:
+                  -
+                    _id: 2
+                    x: 42

--- a/tests/validator-numFailures.yml
+++ b/tests/validator-numFailures.yml
@@ -38,6 +38,12 @@ driverWorkload:
             storeSuccessesAsEntity: successes
             storeFailuresAsEntity: failures
             operations:
+              # Reduce log spam
+              - name: find
+                object: *collection0
+                arguments:
+                  filter: { $where: 'sleep(250)' }
+              
               - name: find
                 object: *collection0
                 arguments:

--- a/tests/validator-simple.yml
+++ b/tests/validator-simple.yml
@@ -51,6 +51,12 @@ driverWorkload:
             storeIterationsAsEntity: iterations
             storeSuccessesAsEntity: successes
             operations:
+              # Reduce number of events produced
+              - name: find
+                object: *collection0
+                arguments:
+                  filter: { $where: 'sleep(250)' }
+              
               - name: updateOne
                 object: *collection0
                 arguments:


### PR DESCRIPTION
Test that uncaptured errors and failures fail the test run.

This PR also adds sleeps on each iteration of validator scenarios to reduce the amount of logs produced and speed up validation (since astrolabe takes some time to parse the produced json files).