### PR TITLE
Add workload executor for the synchronous Java driver

### DIFF
--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -322,10 +322,10 @@ axes:
       - id: java-master
         display_name: "Java (master)"
         variables:
-          DRIVER_DIRNAME: "java"
+          DRIVER_DIRNAME: "java/sync"
           DRIVER_REPOSITORY: "https://github.com/mongodb/mongo-java-driver"
           DRIVER_REVISION: "master"
-          ASTROLABE_EXECUTOR_STARTUP_TIME: 15
+          ASTROLABE_EXECUTOR_STARTUP_TIME: 3
       - id: dotnet-master
         display_name: "dotnet (master)"
         variables:
@@ -473,14 +473,14 @@ buildvariants:
 #  display_name: "${driver} ${platform} ${runtime}"
 #  tasks:
 #    - .all
-#- matrix_name: "tests-java"
-#  matrix_spec:
-#    driver: ["java-master"]
-#    platform: ["ubuntu-18.04"]
-#    runtime: ["java11"]
-#  display_name: "${driver} ${platform} ${runtime}"
-#  tasks:
-#    - ".all"
+- matrix_name: "tests-java"
+  matrix_spec:
+    driver: ["java-master"]
+    platform: ["ubuntu-18.04"]
+    runtime: ["java11"]
+  display_name: "${driver} ${platform} ${runtime}"
+  tasks:
+    - ".all"
 #- matrix_name: "tests-dotnet-windows"
 #  matrix_spec:
 #    driver: ["dotnet-master"]

--- a/integrations/java/install-driver.sh
+++ b/integrations/java/install-driver.sh
@@ -1,7 +1,0 @@
-#!/bin/bash
-
-set -o errexit
-
-cd mongo-java-driver || exit
-
-./gradlew --info driver-workload-executor:compileJava

--- a/integrations/java/sync/install-driver.sh
+++ b/integrations/java/sync/install-driver.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+set -o errexit
+
+cd mongo-java-driver || exit
+./gradlew --info driver-workload-executor:shadowJar
+cd ..
+cp mongo-java-driver/driver-workload-executor/build/libs/driver-workload-executor-*.jar driver-workload-executor.jar
+

--- a/integrations/java/sync/workload-executor
+++ b/integrations/java/sync/workload-executor
@@ -1,0 +1,15 @@
+#!/bin/bash
+
+set -o errexit
+
+workloadExecutorFile="/tmp/java-driver-workload-executor.json"
+
+rm -f "$workloadExecutorFile"
+
+# cat the workload executor JSON to a file
+printf "%s" "$2" > "$workloadExecutorFile"
+
+OUTPUT_DIRECTORY=$PWD
+
+java -Xmx8g -jar -Dorg.mongodb.test.uri="$1" driver-workload-executor.jar $workloadExecutorFile $OUTPUT_DIRECTORY
+

--- a/integrations/java/workload-executor
+++ b/integrations/java/workload-executor
@@ -1,9 +1,0 @@
-#!/bin/bash
-
-set -o errexit
-
-OUTPUT_DIRECTORY=$PWD
-
-cd mongo-java-driver || exit
-
-./gradlew --info  -Dorg.mongodb.workload.output.directory="$OUTPUT_DIRECTORY" -Dorg.mongodb.test.uri="$1" -Dorg.mongodb.workload.spec="$2" driver-workload-executor:run


### PR DESCRIPTION
Probably just one reviewer is sufficient, but not sure who is should be.  Feel free to choose one and remove the other.

Patch build [here](https://evergreen.mongodb.com/build/drivers_atlas_testing_tests_java__driver~java_master_platform~ubuntu_18.04_runtime~java11_patch_86b7d46cdc738755009edbc2ca08b41d85d8d2f5_6050d98c850e61097b2f157c_21_03_16_16_15_22)