### PR TITLE
DRIVERS-1652: Clarify events.json and result.json produced by workload executor

### DIFF
--- a/astrolabe/utils.py
+++ b/astrolabe/utils.py
@@ -166,8 +166,6 @@ def mongo_client(connection_string):
 
 class DriverWorkloadSubprocessRunner:
     """Convenience wrapper to run a workload executor in a subprocess."""
-    _PLACEHOLDER_EXECUTION_STATISTICS = {
-        'numErrors': -1, 'numFailures': -1, 'numSuccesses': -1}
 
     def __init__(self):
         self.is_windows = False
@@ -261,14 +259,14 @@ class DriverWorkloadSubprocessRunner:
             LOGGER.info("Reading sentinel file {!r}".format(self.sentinel))
             with open(self.sentinel, 'r') as fp:
                 stats = json.load(fp)
+                LOGGER.info("Sentinel contains: %s" % json.dumps(stats))
+                return stats
         except FileNotFoundError:
             LOGGER.error("Sentinel file not found")
-            stats = self._PLACEHOLDER_EXECUTION_STATISTICS
+            raise WorkloadExecutorError("The workload executor did not write a results.json file in the expected location")
         except json.JSONDecodeError:
             LOGGER.error("Sentinel file contains malformed JSON")
-            stats = self._PLACEHOLDER_EXECUTION_STATISTICS
-
-        return stats
+            raise WorkloadExecutorError("The workload executor wrote a results.json that contained malformed JSON.")
 
 
 def get_logs(admin_client, project, cluster_name):

--- a/astrolabe/utils.py
+++ b/astrolabe/utils.py
@@ -172,8 +172,8 @@ class DriverWorkloadSubprocessRunner:
         if sys.platform in ("win32", "cygwin"):
             self.is_windows = True
         self.workload_subprocess = None
-        self.sentinel = os.path.join(
-            os.path.abspath(os.curdir), 'results.json')
+        self.sentinel = os.path.join(os.path.abspath(os.curdir), 'results.json')
+        self.events = os.path.join(os.path.abspath(os.curdir), 'events.json')
 
     @property
     def pid(self):
@@ -189,8 +189,13 @@ class DriverWorkloadSubprocessRunner:
 
         try:
             os.remove(self.sentinel)
-            LOGGER.debug("Cleaned up sentinel file at {}".format(
-                self.sentinel))
+            LOGGER.debug("Cleaned up sentinel file at {}".format(self.sentinel))
+        except FileNotFoundError:
+            pass
+
+        try:
+            os.remove(self.events)
+            LOGGER.debug("Cleaned up events file at {}".format(self.events))
         except FileNotFoundError:
             pass
 

--- a/astrolabe/validator.py
+++ b/astrolabe/validator.py
@@ -93,7 +93,7 @@ class ValidateWorkloadExecutor(TestCase):
             # run to error.
             pass
 
-        # The workload executor to permitted to exit prematurely when expecting
+        # The workload executor is permitted to exit prematurely when expecting
         # an error, but it should still report stats via results.json
         try:
             try:

--- a/astrolabe/validator.py
+++ b/astrolabe/validator.py
@@ -253,9 +253,6 @@ class ValidateWorkloadExecutor(TestCase):
         driver_workload = JSONObject.from_dict(
             yaml.safe_load(open('tests/validator-simple.yml').read())['driverWorkload']
         )
-        
-        if os.path.exists('events.json'):
-            os.unlink('events.json')
 
         stats = self.run_test(driver_workload)
         self.assert_basic_stats(stats)

--- a/astrolabe/validator.py
+++ b/astrolabe/validator.py
@@ -13,8 +13,6 @@
 # limitations under the License.
 
 import os, os.path
-from copy import deepcopy
-from subprocess import TimeoutExpired
 from time import sleep
 from unittest import TestCase
 
@@ -52,7 +50,7 @@ class ValidateWorkloadExecutor(TestCase):
             self.fail('Invalid scenario: executor validator test cases must provide database and collection entities')
 
         self.coll = self.client.get_database(dbname).get_collection(collname)
-    
+
     def run_test(self, driver_workload):
         self.set_collection_from_workload(driver_workload)
         
@@ -73,19 +71,8 @@ class ValidateWorkloadExecutor(TestCase):
 
         try:
             stats = subprocess.stop()
-        except TimeoutExpired:
-            self.fail("The workload executor did not terminate soon after "
-                      "receiving the termination signal.")
-
-        # Check that results.json is actually written.
-        if all(val == -1 for val in stats.values()):
-            self.fail("The workload executor did not write a results.json "
-                      "file in the expected location, or the file that was "
-                      "written contained malformed JSON.")
-
-        if any(val < 0 for val in stats.values()):
-            self.fail("The workload executor reported incorrect execution "
-                      "statistics. Reported statistics MUST NOT be negative.")
+        except WorkloadExecutorError as exc:
+            self.fail("WorkloadExecutorError: %s" % exc)
 
         return stats
     
@@ -106,17 +93,161 @@ class ValidateWorkloadExecutor(TestCase):
             # run to error.
             pass
 
+        # The workload executor to permitted to exit prematurely when expecting
+        # an error, but it should still report stats via results.json
         try:
-            stats = subprocess.stop()
-        except PrematureExitError:
-            # OK for workload executor to exit prematurely when we expect
-            # it to fail with an error. We still need to return stats.
-            stats = subprocess.read_stats()
-        except TimeoutExpired:
-            self.fail("The workload executor did not terminate soon after "
-                      "receiving the termination signal.")
+            try:
+                stats = subprocess.stop()
+            except PrematureExitError:
+                stats = subprocess.read_stats()
+        except WorkloadExecutorError as exc:
+            self.fail("WorkloadExecutorError: %s" % exc)
 
         return stats
+
+    # Assert that all keys exist on the object
+    def assert_has_keys(self, obj, keys):
+        for key in keys:
+            if key not in obj:
+                self.fail("Object did not contain expected key: %s" % key)
+
+    # Assert that the parsed stats contain required fields and that numErrors
+    # and numFailures are both set (i.e. not -1)
+    def assert_basic_stats(self, stats):
+        self.assert_has_keys(stats, ['numErrors', 'numFailures', 'numIterations', 'numSuccesses'])
+
+        if stats['numErrors'] < 0:
+            self.fail_stats(
+                "Expected numErrors to be non-negative, but got {} instead."
+                .format(stats['numErrors']))
+
+        if stats['numFailures'] < 0:
+            self.fail_stats(
+                "Expected numFailures to be non-negative, but got {} instead."
+                .format(stats['numFailures']))
+
+    # Assert contents of the events.json file. The presence and type of each
+    # required field (i.e. events, errors, failures) will always be asserted.
+    # Based on the corresponding parameter for each field, the function will
+    # then assert either that the array is empty or that it is non-empty and
+    # each document therein has an expected structure.
+    #
+    # By default, this function will assert that events.json contains some
+    # events but no errors or failures.
+    #
+    # If hasErrorsXorFailures is true, hasErrors and hasFailures will be ignored
+    # and the function will instead assert that either errors or failures are
+    # present (but not both).
+    def assert_events(self, hasEvents=True, hasErrors=False, hasFailures=False,
+                      hasErrorsXorFailures=False):
+        try:
+            events = yaml.safe_load(open('events.json').read())
+        except OSError as exc:
+            self.fail("Failed to open events.json: %s" % exc)
+        except yaml.YAMLError as e:
+            self.fail("Failed to parse events.json: %s" % e)
+
+        # Assert both presence and type of required fields in events.json
+        self.assert_has_keys(events, ['events', 'errors', 'failures'])
+
+        if not isinstance(events['events'], list):
+            self.fail("The workload executor didn't record events as an array.")
+
+        if not isinstance(events['errors'], list):
+            self.fail("The workload executor didn't record errors as an array.")
+
+        if not isinstance(events['failures'], list):
+            self.fail("The workload executor didn't record failrues as an array.")
+
+        # If hasEvents is true, assert that the array is non-empty and that each
+        # object within contains essential fields. If hasEvents is false, the
+        # array should be empty.
+        #
+        # Note: we do not assert the type of events observed since not all
+        # drivers implement CMAP and thus might only log Command events.
+        if hasEvents:
+            if not events['events']:
+                self.fail("The workload executor recorded no events but some were expected")
+
+            numConnectionEvents = 0
+            numPoolEvents = 0
+            numCommandEvents = 0
+
+            for event in events['events']:
+                if ('name' not in event) or (not event['name'].endswith('Event')):
+                    self.fail("The workload executor didn't record event name as expected.")
+
+                if 'observedAt' not in event:
+                    self.fail("The workload executor didn't record event observation time as expected.")
+
+                if event['name'].startswith('Connection'):
+                    numConnectionEvents += 1
+
+                if event['name'].startswith('Pool'):
+                    numPoolEvents += 1
+
+                if event['name'].startswith('Command'):
+                    numCommandEvents += 1
+
+            if numConnectionEvents == 0:
+                self.fail("The workload executor recorded no CMAP connection events but some were expected")
+
+            if numPoolEvents == 0:
+                self.fail("The workload executor recorded no CMAP connection pool events but some were expected")
+
+            if numCommandEvents == 0:
+                self.fail("The workload executor recorded no command monitoring events but some were expected")
+        else:
+            if events['events']:
+                self.fail("The workload executor recorded %d events but none were expected" % len(events['events']))
+
+        # If hasErrorsXorFailures is true, allow either hasErrors or hasFailures
+        # but not both. This is mainly needed for test_num_failures_not_captured
+        # since the workload executor is permitted to report an uncaught failure
+        # as either an error or failure.
+        if hasErrorsXorFailures:
+            # Infer hasErrors and hasFailures from the contents of events.json.
+            # We need only assert xor equivalence here as the function will go
+            # on to assert hasErrors and hasFailures independently.
+            hasErrors = bool(events['errors'])
+            hasFailures = bool(events['failures'])
+
+            if hasErrors and hasFailures:
+                self.fail("The workload executor recorded both errors and failures but only one was expected.")
+
+            if not (hasErrors or hasFailures):
+                self.fail("The workload executor recorded neither errors nor failures but one was expected.")
+
+        # If hasErrors is true, assert that the array is non-empty and that each
+        # object within contains essential fields. If hasErrors is false, the
+        # array should be empty.
+        if hasErrors:
+            if not events['errors']:
+                self.fail("The workload executor recorded no errors but some were expected")
+
+            for error in events['errors']:
+                if ('error' not in error) or ('time' not in error):
+                    self.fail("The workload executor didn't record error as expected: {}".format(error))
+        else:
+            if events['errors']:
+                self.fail("The workload executor recorded %d errors but none were expected" % len(events['errors']))
+
+        # If hasFailures is true, assert that the array is non-empty and that
+        # each object within contains essential fields. If hasFailures is false,
+        # the array should be empty.
+        if hasFailures:
+            if not events['failures']:
+                self.fail("The workload executor recorded no failures but some were expected")
+
+            for failure in events['failures']:
+                if ('error' not in failure) or ('time' not in failure):
+                    self.fail("The workload executor didn't record failure as expected: {}".format(failure))
+        else:
+            if events['failures']:
+                self.fail("The workload executor recorded %d failures but none were expected" % len(events['failures']))
+
+    def fail_stats(self, msg):
+        self.fail("The workload executor reported inconsistent execution statistics. " + str(msg))
 
     def test_simple(self):
         driver_workload = JSONObject.from_dict(
@@ -127,58 +258,42 @@ class ValidateWorkloadExecutor(TestCase):
             os.unlink('events.json')
 
         stats = self.run_test(driver_workload)
+        self.assert_basic_stats(stats)
 
-        num_successes = stats['numSuccesses']
+        # The simple test's loop contains a single updateOne that increments the
+        # document on each iteration. Fetch that value to use for assertions on
+        # numSuccesses and numIterations.
         update_count = self.coll.find_one(
             {'_id': 'validation_sentinel'})['count']
-        if abs(num_successes/2 - update_count) > 1:
-            self.fail(
-                "The workload executor reported inconsistent execution "
-                "statistics. Expected 2*{} successful "
-                "operations to be reported, got {} instead.".format(
-                    update_count, num_successes))
-        if abs(stats['numIterations'] - update_count) > 1:
-            self.fail(
-                "The workload executor reported inconsistent execution "
-                "statistics. Expected {} iterations "
-                "to be reported, got {} instead.".format(
-                    update_count, stats['numIterations']))
+
         if update_count == 0:
             self.fail(
                 "The workload executor didn't execute any operations "
                 "or didn't execute them appropriately.")
-                
-        _events = yaml.safe_load(open('events.json').read())
-        if 'events' not in _events:
+
+        if abs(stats['numSuccesses']/2 - update_count) > 1:
+            self.fail_stats(
+                "Expected 2*{} successful operations to be reported in "
+                "numSuccesses, but got {} instead."
+                .format(update_count, stats['numSuccesses']))
+
+        if abs(stats['numIterations'] - update_count) > 1:
             self.fail(
-                "The workload executor didn't record events as expected.")
-        events = _events['events']
-        connection_events = [event for event in events
-            if event['name'].startswith('Connection')]
-        if not connection_events:
-            self.fail(
-                "The workload executor didn't record connection events as expected.")
-        pool_events = [event for event in events
-            if event['name'].startswith('Pool')]
-        if not pool_events:
-            self.fail(
-                "The workload executor didn't record connection pool events as expected.")
-        command_events = [event for event in events
-            if event['name'].startswith('Command')]
-        if not command_events:
-            self.fail(
-                "The workload executor didn't record command events as expected.")
-        for event_list in [connection_events, pool_events, command_events]:
-            for event in event_list:
-                if 'name' not in event:
-                    self.fail(
-                        "The workload executor didn't record event name as expected.")
-                if not event['name'].endswith('Event'):
-                    self.fail(
-                        "The workload executor didn't record event name as expected.")
-                if 'observedAt' not in event:
-                    self.fail(
-                        "The workload executor didn't record observation time as expected.")
+                "Expected {} iterations to be reported in numIterations, but "
+                "got {} instead."
+                .format(update_count, stats['numIterations']))
+
+        if stats['numErrors'] != 0:
+            self.fail_stats(
+                "Expected no errors to be reported, but got {} instead."
+                .format(stats['numErrors']))
+
+        if stats['numFailures'] != 0:
+            self.fail_stats(
+                "Expected no failures to be reported, but got {} instead."
+                .format(stats['numFailures']))
+
+        self.assert_events(hasEvents=True, hasErrors=False, hasFailures=False)
 
     def test_num_errors(self):
         driver_workload = JSONObject.from_dict(
@@ -186,30 +301,33 @@ class ValidateWorkloadExecutor(TestCase):
         )
 
         stats = self.run_test(driver_workload)
+        self.assert_basic_stats(stats)
 
-        num_successes = stats['numSuccesses']
-        update_count = self.coll.find_one(
-            {'_id': 'validation_sentinel'})['count']
-        if abs(num_successes/2 - update_count) > 1:
-            self.fail(
-                "The workload executor reported inconsistent execution "
-                "statistics. Expected 2*{} successful "
-                "operations to be reported, got {} instead.".format(
-                    update_count, num_successes))
+        # Since the test only uses storeErrorsAsEntity, numFailures should never
+        # be reported. This is irrelevant to whether or how a test runner
+        # distinguishes between errors and failures.
+        if stats['numFailures'] != 0:
+            self.fail_stats(
+                "Expected no failures to be reported, but got {} instead."
+                .format(stats['numFailures']))
 
-        num_reported_errors = stats['numErrors']
-        if abs(num_reported_errors - num_successes/2) > 1:
-            self.fail(
-                "The workload executor reported inconsistent execution "
-                "statistics. Expected approximately {}/2 errored operations "
-                "to be reported, got {} instead.".format(
-                    num_successes, num_reported_errors))
-        if abs(stats['numIterations'] - update_count) > 1:
-            self.fail(
-                "The workload executor reported inconsistent execution "
-                "statistics. Expected {} iterations "
-                "to be reported, got {} instead.".format(
-                    update_count, stats['numIterations']))
+        # Each loop iteration should include two successful sub-operations
+        # followed by one failure, so expect numErrors to be numSuccesses/2
+        if abs(stats['numErrors'] - stats['numSuccesses']/2) > 1:
+            self.fail_stats(
+                "Expected approximately {}/2 errored operations to be reported "
+                "in numErrors, but got {} instead."
+                .format(stats['numSuccesses'], stats['numErrors']))
+
+        # Each loop iteration should include two successful sub-operations, so
+        # expect reported numIterations to be numSuccesses/2
+        if abs(stats['numIterations'] - stats['numSuccesses']/2) > 1:
+            self.fail_stats(
+                "Expected approximately {}/2 iterations to be reported in "
+                "numIterations, but got {} instead."
+                .format(stats['numSuccesses'], stats['numIterations']))
+
+        self.assert_events(hasEvents=False, hasErrors=True, hasFailures=False)
 
     def test_num_errors_not_captured(self):
         driver_workload = JSONObject.from_dict(
@@ -217,14 +335,60 @@ class ValidateWorkloadExecutor(TestCase):
         )
 
         stats = self.run_test_expecting_error(driver_workload)
+        self.assert_basic_stats(stats)
 
-        num_reported_errors = stats['numErrors']
-        if num_reported_errors != -1:
-            self.fail(
-                "The workload executor reported unexpected execution "
-                "statistics. Expected -1 errors since errors were not captured, "
-                "got {} instead.".format(
-                    num_reported_errors))
+        # The workload executor is still expected to report errors propagated
+        # from the unified test runner (e.g. loop operation without
+        # storeErrorsAsEntity and storeFailuresAsEntity).
+        if stats['numErrors'] != 1:
+            self.fail_stats(
+                "Expected one error to be reported, but got {} instead."
+                .format(stats['numErrors']))
+
+        if stats['numFailures'] != 0:
+            self.fail_stats(
+                "Expected no failures to be reported, but got {} instead."
+                .format(stats['numFailures']))
+
+        # Note: we do not assert numSuccesses or numIterations because the spec
+        # does not guarantee that they will be reported via the entity map if
+        # test runner propagates an error/failure.
+
+        # In the event the test runner does not capture an error, the workload
+        # executor is expected to report it in the same format
+        self.assert_events(hasEvents=False, hasErrors=True, hasFailures=False)
+
+    def test_num_errors_as_failures(self):
+        driver_workload = JSONObject.from_dict(
+            yaml.safe_load(open('tests/validator-numErrors-as-failures.yml').read())['driverWorkload']
+        )
+
+        stats = self.run_test(driver_workload)
+        self.assert_basic_stats(stats)
+
+        # Errors should be reported in numFailures instead of numErrors
+        if stats['numErrors'] != 0:
+            self.fail_stats(
+                "Expected no errors to be reported in numErrors, but got {} "
+                "instead.".format(stats['numFailures']))
+
+        # Each loop iteration should include two successful sub-operations
+        # followed by one error, so expect numFailures to be numSuccesses/2
+        if abs(stats['numFailures'] - stats['numSuccesses']/2) > 1:
+            self.fail_stats(
+                "Expected approximately {}/2 errored operations to be reported "
+                "in numFailures, but got {} instead."
+                .format(stats['numSuccesses'], stats['numFailures']))
+
+        # Each loop iteration should include two successful sub-operations, so
+        # expect reported numIterations to be numSuccesses/2
+        if abs(stats['numIterations'] - stats['numSuccesses']/2) > 1:
+            self.fail_stats(
+                "Expected approximately {}/2 iterations to be reported in "
+                "numIterations, but got {} instead."
+                .format(stats['numSuccesses'], stats['numIterations']))
+
+        self.assert_events(hasEvents=False, hasErrors=False, hasFailures=True)
 
     def test_num_failures(self):
         driver_workload = JSONObject.from_dict(
@@ -232,22 +396,33 @@ class ValidateWorkloadExecutor(TestCase):
         )
 
         stats = self.run_test(driver_workload)
+        self.assert_basic_stats(stats)
 
-        num_reported_finds = stats['numSuccesses']
+        # Since the test only uses storeFailuresAsEntity, numErrors should never
+        # be reported. This is irrelevant to whether or how a test runner
+        # distinguishes between errors and failures.
+        if stats['numErrors'] != 0:
+            self.fail_stats(
+                "Expected no errors to be reported, but got {} instead."
+                .format(stats['numErrors']))
 
-        num_reported_failures = stats['numFailures']
-        if abs(num_reported_failures - num_reported_finds/2) > 1:
-            self.fail(
-                "The workload executor reported inconsistent execution "
-                "statistics. Expected approximately {}/2 errored operations "
-                "to be reported, got {} instead.".format(
-                    num_reported_finds, num_reported_failures))
-        if abs(stats['numIterations'] - num_reported_finds/2) > 1:
-            self.fail(
-                "The workload executor reported inconsistent execution "
-                "statistics. Expected {} iterations "
-                "to be reported, got {} instead.".format(
-                    num_reported_finds, stats['numIterations']))
+        # Each loop iteration should include two successful sub-operations
+        # followed by one failure, so expect numFailures to be numSuccesses/2
+        if abs(stats['numFailures'] - stats['numSuccesses']/2) > 1:
+            self.fail_stats(
+                "Expected approximately {}/2 failed operations to be reported "
+                "in numFailures, but got {} instead."
+                .format(stats['numSuccesses'], stats['numFailures']))
+
+        # Each loop iteration should include two successful sub-operations, so
+        # expect reported numIterations to be numSuccesses/2
+        if abs(stats['numIterations'] - stats['numSuccesses']/2) > 1:
+            self.fail_stats(
+                "Expected approximately {}/2 iterations to be reported in "
+                "numIterations, but got {} instead."
+                .format(stats['numSuccesses'], stats['numIterations']))
+
+        self.assert_events(hasEvents=False, hasErrors=False, hasFailures=True)
 
     def test_num_failures_not_captured(self):
         driver_workload = JSONObject.from_dict(
@@ -255,14 +430,29 @@ class ValidateWorkloadExecutor(TestCase):
         )
 
         stats = self.run_test_expecting_error(driver_workload)
+        self.assert_basic_stats(stats)
 
-        num_reported_errors = stats['numFailures']
-        if num_reported_errors != -1:
-            self.fail(
-                "The workload executor reported unexpected execution "
-                "statistics. Expected -1 failures since failures were not captured, "
-                "got {} instead.".format(
-                    num_reported_errors))
+        # The workload executor is still expected to report failures propagated
+        # from the unified test runner (e.g. loop operation without
+        # storeErrorsAsEntity and storeFailuresAsEntity) and is permitted to
+        # report them as errors. For this reason, we must be flexible and allow
+        # either numFailures or numErrors to be reported (but not both).
+        if not ((stats['numErrors'] == 0 and stats['numFailures'] == 1) or
+                (stats['numErrors'] == 1 and stats['numFailures'] == 0)):
+            self.fail_stats(
+                "Expected either numErrors:0 and numFailures:1 or numErrors:1 "
+                "and numFailures:0, but got numErrors:{} and numFailures:{} "
+                "instead."
+                .format(stats['numErrors'], stats['numFailures']))
+
+        # Note: we do not assert numSuccesses or numIterations because the spec
+        # does not guarantee that they will be reported via the entity map if
+        # test runner propagates an error/failure.
+
+        # In the event the test runner does not capture a failure, the workload
+        # executor is expected to report it in the same format; however, it may
+        # be reported as either an error or failure
+        self.assert_events(hasEvents=False, hasErrorsXorFailures=True)
 
     def test_num_failures_as_errors(self):
         driver_workload = JSONObject.from_dict(
@@ -270,30 +460,31 @@ class ValidateWorkloadExecutor(TestCase):
         )
 
         stats = self.run_test(driver_workload)
+        self.assert_basic_stats(stats)
 
-        num_reported_finds = stats['numSuccesses']
+        # Failures should be reported in numErrors instead of numFailures
+        if stats['numFailures'] != 0:
+            self.fail_stats(
+                "Expected no failures to be reported in numFailures, but got "
+                "{} instead.".format(stats['numFailures']))
 
-        num_reported_errors = stats['numErrors']
-        num_reported_failures = stats['numFailures']
-        if abs(num_reported_errors - num_reported_finds/2) > 1:
+        # Each loop iteration should include two successful sub-operations
+        # followed by one failure, so expect numErrors to be numSuccesses/2
+        if abs(stats['numErrors'] - stats['numSuccesses']/2) > 1:
             self.fail(
-                "The workload executor reported inconsistent execution "
-                "statistics. Expected approximately {}/2 errored operations "
-                "to be reported, got {} instead.".format(
-                    num_reported_finds, num_reported_failures))
-        if num_reported_failures > 0:
-            self.fail(
-                "The workload executor reported unexpected execution "
-                "statistics. Expected all failures to be reported as errors, "
-                "got {} failures instead.".format(
-                    num_reported_failures))
-        if abs(stats['numIterations'] - num_reported_finds/2) > 1:
-            self.fail(
-                "The workload executor reported inconsistent execution "
-                "statistics. Expected {} iterations "
-                "to be reported, got {} instead.".format(
-                    num_reported_finds, stats['numIterations']))
+                "Expected approximately {}/2 failed operations to be reported "
+                "in numErrors, but got {} instead."
+                .format(stats['numSuccesses'], stats['numErrors']))
 
+        # Each loop iteration should include two successful sub-operations, so
+        # expect reported numIterations to be numSuccesses/2
+        if abs(stats['numIterations'] - stats['numSuccesses']/2) > 1:
+            self.fail(
+                "Expected approximately {}/2 iterations to be reported in "
+                "numIterations, but got {} instead."
+                .format(stats['numSuccesses'], stats['numIterations']))
+
+        self.assert_events(hasEvents=False, hasErrors=True, hasFailures=False)
 
 def validator_factory(workload_executor, connection_string, startup_time):
     ValidateWorkloadExecutor.WORKLOAD_EXECUTOR = workload_executor

--- a/docs/source/spec-test-format.rst
+++ b/docs/source/spec-test-format.rst
@@ -130,17 +130,21 @@ A Test Scenario File has the following keys:
   be exactly one ``loop`` operation per scenario, and it SHOULD be the last
   operation in the scenario.
 
-  The scenario MUST use ``storeErrorsAsEntity``, ``storeFailuresAsEntity``,
-  ``storeSuccessesAsEntity`` and ``storeIterationsAsEntity`` operation arguments
-  to allow the workload executor to retrieve errors, failures and operation
-  counts for the executed workload. The entity names for these options MUST
-  be as follows:
-  
+  The scenario MUST use ``storeErrorsAsEntity``, ``storeSuccessesAsEntity``,
+  and ``storeIterationsAsEntity`` operation arguments to allow the workload
+  executor to retrieve errors, failures, and operation and iteration counts for
+  the executed workload. The entity names for these options MUST be as follows:
+
   - ``storeErrorsAsEntity``: ``errors``
-  - ``storeFailuresAsEntity``: ``failures``
   - ``storeSuccessesAsEntity``: ``successes``
   - ``storeIterationsAsEntity``: ``iterations``
-  
+
+  The scenario MUST NOT use ``storeFailuresAsEntity`` to ensure that all errors
+  and failures are reported under a single ``errors`` entity irrespective of how
+  a test runner might distinguish errors and failures (if at all). Note that
+  some ValidateWorkloadExecutor tests may still use ``storeFailuresAsEntity``
+  with the entity name ``failures`` to assert workload executor correctness.
+
   The scenario MUST use ``storeEventsAsEntities`` operation argument
   when defining MongoClients to record CMAP and command events published
   during maintenance. All events MUST be stored in an entity named ``events``.

--- a/tests/validator-numErrors-as-failures.yml
+++ b/tests/validator-numErrors-as-failures.yml
@@ -1,10 +1,10 @@
-# This file intentionally causes the workload executor to produce a failure
+# This file intentionally causes the workload executor to produce an error
 # on each execution.
 
 operations: []
 
 driverWorkload:
-  description: "Validator - numFailures not captured"
+  description: "Validator - numErrors as failures"
 
   schemaVersion: "1.2"
 
@@ -25,17 +25,18 @@ driverWorkload:
       databaseName: *database0Name
       documents:
         -
-          _id: 2
-          x: 2
+          _id: validation_sentinel
+          count: 0
 
   tests:
-    - description: "Find one & failure"
+    - description: "updateOne & error"
       operations:
         - name: loop
           object: testRunner
           arguments:
             storeIterationsAsEntity: iterations
             storeSuccessesAsEntity: successes
+            storeFailuresAsEntity: failures
             operations:
               # Reduce log spam
               - name: find
@@ -43,21 +44,14 @@ driverWorkload:
                 arguments:
                   filter: { $where: 'sleep(250)' }
               
-              - name: find
+              - name: updateOne
                 object: *collection0
                 arguments:
-                  filter: { _id: { $gt: 1 }}
-                  sort: { _id: 1 }
-                expectResult:
-                  -
-                    _id: 2
-                    x: 2
-              - name: find
+                  filter: { _id: validation_sentinel}
+                  update: 
+                    $inc:
+                      count: 1
+              - name: doesNotExist
                 object: *collection0
                 arguments:
-                  filter: { _id: { $gt: 1 }}
-                  sort: { _id: 1 }
-                expectResult:
-                  -
-                    _id: 2
-                    x: 42
+                  foo: bar

--- a/tests/validator-numErrors-not-captured.yml
+++ b/tests/validator-numErrors-not-captured.yml
@@ -4,7 +4,7 @@
 operations: []
 
 driverWorkload:
-  description: "Validator - num errors"
+  description: "Validator - numErrors not captured"
 
   schemaVersion: "1.2"
 

--- a/tests/validator-numErrors.yml
+++ b/tests/validator-numErrors.yml
@@ -4,7 +4,7 @@
 operations: []
 
 driverWorkload:
-  description: "Validator - num errors"
+  description: "Validator - numErrors"
 
   schemaVersion: "1.2"
 

--- a/tests/validator-numFailures-as-errors.yml
+++ b/tests/validator-numFailures-as-errors.yml
@@ -4,7 +4,7 @@
 operations: []
 
 driverWorkload:
-  description: "Validator - num failures"
+  description: "Validator - numFailures as errors"
 
   schemaVersion: "1.2"
 

--- a/tests/validator-numFailures.yml
+++ b/tests/validator-numFailures.yml
@@ -4,7 +4,7 @@
 operations: []
 
 driverWorkload:
-  description: "Validator - num failures"
+  description: "Validator - numFailures"
 
   schemaVersion: "1.2"
 


### PR DESCRIPTION
https://jira.mongodb.org/browse/DRIVERS-1652

This should also address [DRIVERS-1604](https://jira.mongodb.org/browse/DRIVERS-1604).