### PR TITLE
DRIVERS-1659 Increase timeout in testFailover operation

### DIFF
--- a/astrolabe/runner.py
+++ b/astrolabe/runner.py
@@ -191,7 +191,7 @@ class AtlasTestCase:
             elif op_name == 'testFailover':
                 timer = Timer()
                 timer.start()
-                timeout = 90
+                timeout = 300
 
                 # DRIVERS-1585: failover may fail due to the cluster not being
                 # ready. Retry failover up to a timeout if the


### PR DESCRIPTION
Increases the timeout to 5 minutes to hopefully cover all of these failures.