### PR TITLE
DRIVER-1716 fix spec for numFailures and numErrors if the arrays don'…

### DIFF
--- a/docs/source/spec-workload-executor.rst
+++ b/docs/source/spec-workload-executor.rst
@@ -160,7 +160,7 @@ After accepting the inputs, the workload executor:
    (``numFailures``) from the error and failure lists. If the errors or
    failures were not reported by the test runner, such as because the
    respective options were not specified in the test scenario, the workload
-   executor MUST use ``-1`` as the value for the respective counts.
+   executor MUST use ``0`` as the value for the respective counts.
 
 #. MUST write the collected workload statistics into a JSON file named
    ``results.json`` in the current working directory (i.e. the directory


### PR DESCRIPTION
…t exist

I wasn't sure if we should remove the step entirely, but I thought it might still be worthwhile to specify what happens if the entities don't exist