### PR TITLE
Add retry to downloading the dotnet install script.

### DIFF
--- a/integrations/dotnet/install-driver.sh
+++ b/integrations/dotnet/install-driver.sh
@@ -5,7 +5,16 @@ set -o errexit  # Exit the script with error if any of the commands fail
 # Environment variables used as input:
 #   FRAMEWORK                       Set to specify .NET framework to test against. Values: "netcoreapp2.1"
 
-curl -sSL https://dot.net/v1/dotnet-install.ps1 -o integrations/dotnet/dotnet-install.ps1
+# Download the dotnet installation script, retrying up to 5 times on any errors.
+curl -sSL \
+    --max-time 20 \
+    --retry 5 \
+    --retry-delay 0 \
+    --retry-max-time 60 \
+    --retry-all-errors \
+    -o integrations/dotnet/dotnet-install.ps1 \
+    https://dot.net/v1/dotnet-install.ps1
+
 # the below .ps1 script install .net50 into ${LOCALAPPDATA}/Microsoft/dotnet which we should use to build and publish the project
 powershell.exe '.\integrations\dotnet\dotnet-install.ps1 -Channel 5.0 '
 


### PR DESCRIPTION
.NET driver build can sometimes fail because the `dotnet` CLI install script fails to download. Example failure log:
```
[2022/04/20 18:20:38.508] + set -o errexit
[2022/04/20 18:20:38.508] + curl -sSL https://dot.net/v1/dotnet-install.ps1 -o integrations/dotnet/dotnet-install.ps1
[2022/04/20 18:21:25.636] curl: (92) HTTP/2 stream 0 was not closed cleanly: PROTOCOL_ERROR (err 1)
...
[2022/04/20 18:32:24.415] Could not execute because the specified command or file was not found.
[2022/04/20 18:32:24.415] Possible reasons for this include:
...
```
Improve reliability of the .NET `install-driver.sh` script by retrying the install script download up to 5 times.