### PR TITLE
CLOUDP-100718 Improve Astrolabe Testing

### DIFF
--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -107,7 +107,7 @@ functions:
           ATLAS_API_USERNAME: ${atlas_key}
           ATLAS_API_PASSWORD: ${atlas_secret}
           ATLAS_API_BASE_URL: ${atlas_url}
-          ATLAS_ORGANIZATION_NAME: ${atlas_organization}
+          ATLAS_ORGANIZATION_ID: ${atlas_organization}
           ATLAS_ADMIN_API_USERNAME: ${atlas_admin_api_username}
           ATLAS_ADMIN_API_PASSWORD: ${atlas_admin_api_password}
         add_expansions_to_env: true
@@ -139,7 +139,7 @@ functions:
           ATLAS_API_USERNAME: ${atlas_key}
           ATLAS_API_PASSWORD: ${atlas_secret}
           ATLAS_API_BASE_URL: ${atlas_url}
-          ATLAS_ORGANIZATION_NAME: ${atlas_organization}
+          ATLAS_ORGANIZATION_ID: ${atlas_organization}
           ATLAS_ADMIN_API_USERNAME: ${atlas_admin_api_username}
           ATLAS_ADMIN_API_PASSWORD: ${atlas_admin_api_password}
         add_expansions_to_env: true
@@ -175,7 +175,7 @@ functions:
           ATLAS_API_USERNAME: ${atlas_key}
           ATLAS_API_PASSWORD: ${atlas_secret}
           ATLAS_API_BASE_URL: ${atlas_url}
-          ATLAS_ORGANIZATION_NAME: ${atlas_organization}
+          ATLAS_ORGANIZATION_ID: ${atlas_organization}
           ATLAS_ADMIN_API_USERNAME: ${atlas_admin_api_username}
           ATLAS_ADMIN_API_PASSWORD: ${atlas_admin_api_password}
         add_expansions_to_env: true

--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -107,7 +107,7 @@ functions:
           ATLAS_API_USERNAME: ${atlas_key}
           ATLAS_API_PASSWORD: ${atlas_secret}
           ATLAS_API_BASE_URL: ${atlas_url}
-          ATLAS_ORGANIZATION_ID: ${atlas_organization}
+          ATLAS_ORGANIZATION_ID: ${atlas_organization_id}
           ATLAS_ADMIN_API_USERNAME: ${atlas_admin_api_username}
           ATLAS_ADMIN_API_PASSWORD: ${atlas_admin_api_password}
         add_expansions_to_env: true
@@ -139,7 +139,7 @@ functions:
           ATLAS_API_USERNAME: ${atlas_key}
           ATLAS_API_PASSWORD: ${atlas_secret}
           ATLAS_API_BASE_URL: ${atlas_url}
-          ATLAS_ORGANIZATION_ID: ${atlas_organization}
+          ATLAS_ORGANIZATION_ID: ${atlas_organization_id}
           ATLAS_ADMIN_API_USERNAME: ${atlas_admin_api_username}
           ATLAS_ADMIN_API_PASSWORD: ${atlas_admin_api_password}
         add_expansions_to_env: true
@@ -175,7 +175,7 @@ functions:
           ATLAS_API_USERNAME: ${atlas_key}
           ATLAS_API_PASSWORD: ${atlas_secret}
           ATLAS_API_BASE_URL: ${atlas_url}
-          ATLAS_ORGANIZATION_ID: ${atlas_organization}
+          ATLAS_ORGANIZATION_ID: ${atlas_organization_id}
           ATLAS_ADMIN_API_USERNAME: ${atlas_admin_api_username}
           ATLAS_ADMIN_API_PASSWORD: ${atlas_admin_api_password}
         add_expansions_to_env: true

--- a/astrolabe/commands.py
+++ b/astrolabe/commands.py
@@ -22,17 +22,11 @@ from atlasclient import AtlasApiError
 LOGGER = logging.getLogger(__name__)
 
 
-def get_one_organization_by_name(*, client, organization_name):
-    """Get the ID of the organization by the given name. Raises
-    AtlasApiError if no organization exists by the given name."""
-    all_orgs = client.orgs.get().data
-    for org in all_orgs.results:
-        if org.name == organization_name:
-            LOGGER.debug("Organization details: {}".format(org))
-            return org
-
-    raise AtlasApiError('Organization {!r} not found.'.format(
-        organization_name))
+def get_organization_by_id(*, client, org_id):
+    """Get the organization by the given id `org_id`."""
+    org = client.orgs[org_id].get().data 
+    LOGGER.debug("Organization details: {}".format(org))   
+    return org    
 
 
 def ensure_project(*, client, project_name, organization_id):
@@ -52,6 +46,21 @@ def ensure_project(*, client, project_name, organization_id):
 
     LOGGER.debug("Project details: {}".format(project))
     return project
+
+
+def list_projects_in_org(*, client, org_id):
+    """List all projects inside organization with id `org_id`."""
+    projects_res = client.orgs[org_id].groups.get(
+            itemsPerPage=500).data
+    LOGGER.debug("Retrieved {} projects in org id: {}".format(projects_res.totalCount, org_id))
+    return projects_res
+
+
+def delete_project(*, client, project_id):
+    """Delete a project with id `project_id`"""    
+    client.groups[project_id].delete().data
+    
+    LOGGER.debug("Deleted project id: {}".format(project_id))
 
 
 def ensure_admin_user(*, client, project_id, username, password):

--- a/astrolabe/configuration.py
+++ b/astrolabe/configuration.py
@@ -76,6 +76,11 @@ CONFIGURATION_OPTIONS = JSONObject({
         'cliopt': '--org-name',
         'envvar': 'ATLAS_ORGANIZATION_NAME',
         'default': 'MongoDB Drivers Team'},
+    'ATLAS_ORGANIZATION_ID': {
+        'help': 'ID of the Atlas Organization.',
+        'cliopt': '--org-id',
+        'envvar': 'ATLAS_ORGANIZATION_ID',
+        'default': None},
     'ATLAS_API_BASE_URL': {
         'help': 'Base URL of the Atlas API.',
         'cliopt': '--atlas-base-url',
@@ -107,6 +112,6 @@ CONFIGURATION_OPTIONS = JSONObject({
 # Convenience class for storing settings related to polling.
 TestCaseConfiguration = namedtuple(
     "AtlasPlannedMaintenanceTestConfiguration",
-    ["organization_name", "project_name", "name_salt", "polling_timeout",
+    ["organization_name", "organization_id", "project_name", "name_salt", "polling_timeout",
      "polling_frequency", "database_username", "database_password",
      "workload_executor"])

--- a/astrolabe/docgen.py
+++ b/astrolabe/docgen.py
@@ -40,7 +40,8 @@ def generate_configuration_help():
 
 def tabulate_astrolabe_configuration(config):
     table_data = [["Atlas organization name", config.organization_name],
-                  ["Atlas project name", config.project_name],
+                  ["Atlas organization id", config.organization_id],
+                  ["Atlas project name prefix", config.project_name],
                   ["Salt for cluster names", config.name_salt],
                   ["Polling frequency (Hz)", config.polling_frequency],
                   ["Polling timeout (s)", config.polling_timeout]]

--- a/docs/source/installing-running-locally.rst
+++ b/docs/source/installing-running-locally.rst
@@ -61,14 +61,14 @@ Each API key consists of 2 parts - a public key and a private key.
 To configure ``astrolabe`` to use production Atlas and specify only a regular
 API key, declare the following variables::
 
-  $ export ATLAS_ORGANIZATION_NAME=<Atlas Organization Name>
+  $ export ATLAS_ORGANIZATION_ID=<Atlas Organization Id>
   $ export ATLAS_API_USERNAME=<API Public Key>
   $ export ATLAS_API_PASSWORD=<API Private Key>
 
 To configure ``astrolabe`` to use development Atlas and specify two sets of
 API keys, declare the following variables::
 
-  $ export ATLAS_ORGANIZATION_NAME=<Atlas Organization Name>
+  $ export ATLAS_ORGANIZATION_ID=<Atlas Organization Id>
   $ export ATLAS_API_USERNAME=<API Public Key>
   $ export ATLAS_API_PASSWORD=<API Private Key>
   $ export ATLAS_ADMIN_API_USERNAME=<Admin API Public Key>


### PR DESCRIPTION
Improvements made:
* Searching by organization name is inefficient as you have to page (the code doesn't look like it's paging either) through thousands of organizations before finding a string match.  There's a high chance of naming collision too since name is not unique. 
    * This will require all env variables to be updated to org id rather than org name
* Creates a new project per AtlasTestCase with the suffix being the epoch timestamp in seconds. Ex: [ERICATEST-1651857784](https://cloud-qa.mongodb.com/v2/627559788a1e082d1ad4bbfc#)
* Cleans up any old projects in the organizations that have an epoch timestamp that exceeds 12 hours from current time. 