### PR TITLE
use mongodb/rust main branch for Rust testing

### DIFF
--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -429,8 +429,8 @@ axes:
         display_name: "Rust (main)"
         variables:
           DRIVER_DIRNAME: "rust"
-          DRIVER_REPOSITORY: "https://github.com/isabelatkinson/mongo-rust-driver"
-          DRIVER_REVISION: "add-workload-executor"
+          DRIVER_REPOSITORY: "https://github.com/mongodb/mongo-rust-driver"
+          DRIVER_REVISION: "main"
           ASTROLABE_EXECUTOR_STARTUP_TIME: 10
 
   # The 'platform' axis specifies the evergreen host distro to use.


### PR DESCRIPTION
I wanted to run a patch to make sure adding `ConnectionInfo.server_id` to the monitoring events wouldn't break anything and in the process noticed we forgot to switch this before the PR got merged. 