### PR TITLE
DRIVERS-2409 Increase documented minimum Python version to 3.7

### DIFF
--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -51,7 +51,7 @@ functions:
         continue_on_err: true
         command: |
           cat /etc/resolv.conf
-    # Create virtualenv using a CPython 3.5+ binary.
+    # Create virtualenv using a CPython 3.7+ binary.
     - command: subprocess.exec
       type: setup
       params:

--- a/README.rst
+++ b/README.rst
@@ -19,7 +19,7 @@ interface. The ``astrolabe`` package provides a convenient, command-line
 interface to the ``atlasclient`` and also contains the test harnesses
 necessary to run Atlas Planned Maintenance specification tests.
 
-Astrolabe supports Python 3.5+.
+Astrolabe supports Python 3.7+.
 
 Installation
 ============
@@ -37,7 +37,7 @@ You can also download the project source and do::
 Dependencies
 ============
 
-Astrolabe supports CPython 3.5+.
+Astrolabe supports CPython 3.7+.
 
 Astrolabe requires `Click <https://pypi.org/project/click/>`_,
 `requests <https://pypi.org/project/requests/>`_,

--- a/docs/source/installing-running-locally.rst
+++ b/docs/source/installing-running-locally.rst
@@ -13,7 +13,7 @@ Platform Support
 
 ``astrolabe`` runs on Linux, OSX and Windows.
 
-Running ``astrolabe`` requires Python 3.5 or later. To check the version of Python you are running, do::
+Running ``astrolabe`` requires Python 3.7 or later. To check the version of Python you are running, do::
 
   $ python --version
 

--- a/docs/source/integration-guide.rst
+++ b/docs/source/integration-guide.rst
@@ -144,13 +144,13 @@ Adding a Platform
    `ubuntu1804-drivers-atlas-testing <https://evergreen.mongodb.com/distros#%23ubuntu1804-drivers-atlas-testing>`_
    distro for running their tests. See :ref:`faq-why-custom-distro` for details.
 
-The Atlas Planned Maintenance tests can be run on all platforms which have a Python 3.5+ binary installed.
+The Atlas Planned Maintenance tests can be run on all platforms which have a Python 3.7+ binary installed.
 Each entry to the ``platform`` axis has the following fields:
 
 * ``id`` (required): unique identifier for this ``platform`` axis entry.
 * ``display_name`` (optional): plaintext name for this platform that will be used to display test runs.
 * ``run_on`` (required): evergreen distro name for this platform
-* ``variables.PYTHON3_BINARY`` (required): path to the Python 3.5+ binary on the distro. This is used to run
+* ``variables.PYTHON3_BINARY`` (required): path to the Python 3.7+ binary on the distro. This is used to run
   ``astrolabe``.
 * ``variables.PYTHON_BIN_DIR`` (required): name of directory in which Python install executables. This is always
   ``bin`` on \*nix systems and ``Scripts`` on Windows.

--- a/setup.py
+++ b/setup.py
@@ -44,7 +44,7 @@ setup(
     url="https://github.com/mongodb-labs/drivers-atlas-testing",
     keywords=["mongodb", "mongodbatlas", "atlas", "mongo"],
     license="Apache License, Version 2.0",
-    python_requires=">=3.5",
+    python_requires=">=3.7",
     packages=["atlasclient", "astrolabe"],
     install_requires=install_requires,
     entry_points={
@@ -54,9 +54,8 @@ setup(
         "Intended Audience :: Developers",
         "License :: OSI Approved :: Apache Software License",
         "Operating System :: OS Independent",
-        "Programming Language :: Python :: 3.5",
-        "Programming Language :: Python :: 3.6",
         "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",
+        "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: Implementation :: CPython",
         "Topic :: Software Development :: Testing"])


### PR DESCRIPTION
[DRIVERS-2409](https://jira.mongodb.org/browse/DRIVERS-2409)

Increase the minimum Python version to 3.7 in all documentation. Also add a classifier for Python 3.9 in `setup.py`.