### PR TITLE
Fix workload executor validator test paths.

### DIFF
--- a/astrolabe/validator.py
+++ b/astrolabe/validator.py
@@ -252,7 +252,7 @@ class ValidateWorkloadExecutor(TestCase):
         self.fail("The workload executor reported inconsistent execution statistics. " + str(msg))
 
     def test_simple(self):
-        with open('tests/validator-simple.yml') as f:
+        with open('tests/validator/validator-simple.yml') as f:
             driver_workload = JSONObject.from_dict(yaml.safe_load(f)['driverWorkload'])
 
         stats = self.run_test(driver_workload)
@@ -294,7 +294,7 @@ class ValidateWorkloadExecutor(TestCase):
         self.assert_events(hasEvents=True, hasErrors=False, hasFailures=False)
 
     def test_num_errors(self):
-        with open('tests/validator-numErrors.yml') as f:
+        with open('tests/validator/validator-numErrors.yml') as f:
             driver_workload = JSONObject.from_dict(yaml.safe_load(f)['driverWorkload'])
 
         stats = self.run_test(driver_workload)
@@ -327,7 +327,7 @@ class ValidateWorkloadExecutor(TestCase):
         self.assert_events(hasEvents=False, hasErrors=True, hasFailures=False)
 
     def test_num_errors_not_captured(self):
-        with open('tests/validator-numErrors-not-captured.yml') as f:
+        with open('tests/validator/validator-numErrors-not-captured.yml') as f:
             driver_workload = JSONObject.from_dict(yaml.safe_load(f)['driverWorkload'])
 
         stats = self.run_test_expecting_error(driver_workload)
@@ -355,7 +355,7 @@ class ValidateWorkloadExecutor(TestCase):
         self.assert_events(hasEvents=False, hasErrors=True, hasFailures=False)
 
     def test_num_errors_as_failures(self):
-        with open('tests/validator-numErrors-as-failures.yml') as f:
+        with open('tests/validator/validator-numErrors-as-failures.yml') as f:
             driver_workload = JSONObject.from_dict(yaml.safe_load(f)['driverWorkload'])
 
         stats = self.run_test(driver_workload)
@@ -386,7 +386,7 @@ class ValidateWorkloadExecutor(TestCase):
         self.assert_events(hasEvents=False, hasErrors=False, hasFailures=True)
 
     def test_num_failures(self):
-        with open('tests/validator-numFailures.yml') as f:
+        with open('tests/validator/validator-numFailures.yml') as f:
             driver_workload = JSONObject.from_dict(yaml.safe_load(f)['driverWorkload'])
 
         stats = self.run_test(driver_workload)
@@ -419,7 +419,7 @@ class ValidateWorkloadExecutor(TestCase):
         self.assert_events(hasEvents=False, hasErrors=False, hasFailures=True)
 
     def test_num_failures_not_captured(self):
-        with open('tests/validator-numFailures-not-captured.yml') as f:
+        with open('tests/validator/validator-numFailures-not-captured.yml') as f:
             driver_workload = JSONObject.from_dict(yaml.safe_load(f)['driverWorkload'])
 
         stats = self.run_test_expecting_error(driver_workload)
@@ -448,7 +448,7 @@ class ValidateWorkloadExecutor(TestCase):
         self.assert_events(hasEvents=False, hasErrorsXorFailures=True)
 
     def test_num_failures_as_errors(self):
-        with open('tests/validator-numFailures-as-errors.yml') as f:
+        with open('tests/validator/validator-numFailures-as-errors.yml') as f:
             driver_workload = JSONObject.from_dict(yaml.safe_load(f)['driverWorkload'])
 
         stats = self.run_test(driver_workload)


### PR DESCRIPTION
The validator test paths got messed up while resolving a merge conflict in https://github.com/mongodb-labs/drivers-atlas-testing/pull/141. This fixes them.