### PR TITLE
DRIVERS-2419 Run .NET Kind tests on Linux.

### DIFF
--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -74,24 +74,18 @@ functions:
         working_dir: astrolabe-src
         command: |
           git clone --depth 1 --recurse-submodules --shallow-submodules --branch ${DRIVER_REVISION} ${DRIVER_REPOSITORY}
-    # Install driver on *nix platforms.
-    - command: subprocess.exec
+    # Run the install-driver.sh shell script.
+    - command: shell.exec
       type: setup
       params:
         working_dir: astrolabe-src
-        continue_on_err: true       # Because script may not exist OR platform may not be *nix.
         add_expansions_to_env: true
-        command: |
-          integrations/${DRIVER_DIRNAME}/install-driver.sh
-    # Install driver on Windows.
-    - command: subprocess.exec
-      type: setup
-      params:
-        working_dir: astrolabe-src
-        continue_on_err: true       # Because script may not exist OR platform may not be Windows.
-        add_expansions_to_env: true
-        command: |
-          C:/cygwin/bin/sh integrations/${DRIVER_DIRNAME}/install-driver.sh
+        script: |
+          if [ "Windows_NT" = "$OS" ]; then
+            C:/cygwin/bin/sh integrations/${DRIVER_DIRNAME}/install-driver.sh
+          else
+            ./integrations/${DRIVER_DIRNAME}/install-driver.sh
+          fi
 
   "validate executor":
     # Run a MongoDB instance locally.
@@ -252,17 +246,25 @@ functions:
         working_dir: astrolabe-src
         add_expansions_to_env: true
         script: |
-          # Use absolute paths to the TLS cert and CA files in the connection string. Not all
-          # drivers evaluate relative paths in the connection string from the same directory, so
-          # using relative paths can be tricky. The "mongodb_tls_cert.pem" file is written by the
-          # "kubernetes/kind/create.sh" script.
-          CERT_PATH="$(pwd)/mongodb_tls_cert.pem"
-          CA_PATH="$(pwd)/kubernetes/kind/rootCA.pem"
+          # If there is a KIND_CONNSTRING provided by the driver task, use that as the connection
+          # string. Otherwise, use the standard connection string that works for most drivers.
+          if [ ! -z "${KIND_CONNSTRING}" ]; then
+            CONNSTRING="${KIND_CONNSTRING}"
+          else
+            # Use absolute paths to the TLS cert and CA files in the connection string. Not all
+            # drivers evaluate relative paths in the connection string from the same directory, so
+            # using relative paths can be tricky. The "mongodb_tls_cert.pem" file is written by the
+            # "kubernetes/kind/create.sh" script.
+            CERT_PATH="$(pwd)/mongodb_tls_cert.pem"
+            CA_PATH="$(pwd)/kubernetes/kind/rootCA.pem"
+            CONNSTRING="mongodb://user:12345@localhost:31181,localhost:31182,localhost:31183/admin?tls=true&tlsCertificateKeyFile=$CERT_PATH&tlsCAFile=$CA_PATH"
+          fi
+
           astrolabevenv/${PYTHON_BIN_DIR}/astrolabe kubernetes-tests \
             run-one ${TEST_FILE} \
             --workload-file ${WORKLOAD_FILE} \
             --workload-executor integrations/${DRIVER_DIRNAME}/workload-executor \
-            --connection-string "mongodb://user:12345@localhost:31181,localhost:31182,localhost:31183/admin?tls=true&tlsCertificateKeyFile=$CERT_PATH&tlsCAFile=$CA_PATH"
+            --connection-string "$CONNSTRING"
 
   # TODO(DRIVERS-2424): Fix Kind logs retrieval.
   "retrieve kind logs":
@@ -579,12 +581,12 @@ axes:
           DRIVER_REPOSITORY: "https://github.com/mongodb/mongo-csharp-driver"
           DRIVER_REVISION: "master"
           ASTROLABE_EXECUTOR_STARTUP_TIME: 40
-          DOTNET_CLI_HOME: "Z:/"
-          TMP: "Z:/"
-          TEMP: "Z:/"
-          NUGET_PACKAGES: "Z:/"
-          NUGET_HTTP_CACHE_PATH: "Z:/"
-          APPDATA: "Z:/"
+          # The .NET driver currently doesn't support loading TLS and CA certs from connection
+          # string params, so override the standard Kind connection string with one that uses
+          # "tlsInsecure=true" to ignore the validity of the custom CA and TLS certs that the Kind
+          # clusters use.
+          # TODO(DRIVERS-2428): Update .NET workload executor in Astrolabe to support TLS secrets.
+          KIND_CONNSTRING: "mongodb://user:12345@localhost:31181,localhost:31182,localhost:31183/admin?tls=true&tlsInsecure=true"
       - id: go-master
         display_name: "Go (master)"
         variables:
@@ -747,6 +749,17 @@ buildvariants:
   tasks:
     # Kind tasks can't run on Windows, so exclude them.
     - ".all !.kind"
+- matrix_name: "tests-dotnet-linux"
+  matrix_spec:
+    driver: ["dotnet-master"]
+    platform: ["ubuntu-18.04"]
+    runtime:
+      - "dotnet-async-netcoreapp2.1"
+      - "dotnet-sync-netcoreapp2.1"
+  display_name: "${driver} ${platform} ${runtime}"
+  tasks:
+    # Only run the Kind tasks for the .NET driver on Linux.
+    - ".kind"
 - matrix_name: "tests-go"
   matrix_spec:
     driver: ["go-master"]

--- a/integrations/dotnet/install-driver.sh
+++ b/integrations/dotnet/install-driver.sh
@@ -5,22 +5,50 @@ set -o errexit  # Exit the script with error if any of the commands fail
 # Environment variables used as input:
 #   FRAMEWORK                       Set to specify .NET framework to test against. Values: "netcoreapp2.1"
 
-# Download the dotnet installation script, retrying up to 5 times on any errors.
-curl -sSL \
-    --max-time 20 \
-    --retry 5 \
-    --retry-delay 0 \
-    --retry-max-time 60 \
-    --retry-all-errors \
-    -o integrations/dotnet/dotnet-install.ps1 \
-    https://dot.net/v1/dotnet-install.ps1
+export DOTNET_SKIP_FIRST_TIME_EXPERIENCE=1
+export DOTNET_CLI_TELEMETRY_OPTOUT=1
 
-# the below .ps1 script install .net50 into ${LOCALAPPDATA}/Microsoft/dotnet which we should use to build and publish the project
-powershell.exe '.\integrations\dotnet\dotnet-install.ps1 -Channel 5.0 '
+if [[ "$OS" =~ Windows|windows ]]; then
+    export DOTNET_CLI_HOME="Z:/"
+    export TMP="Z:/"
+    export TEMP="Z:/"
+    export NUGET_PACKAGES="Z:/"
+    export NUGET_HTTP_CACHE_PATH="Z:/"
+    export APPDATA="Z:/"
+
+    # Download the dotnet installation script, retrying up to 5 times on any errors.
+    curl -sSL \
+        --max-time 20 \
+        --retry 5 \
+        --retry-delay 0 \
+        --retry-max-time 60 \
+        --retry-all-errors \
+        -o integrations/dotnet/dotnet-install.ps1 \
+        https://dot.net/v1/dotnet-install.ps1
+
+    # Install the v5.0 SDK to build the driver and the v2.1 SDK to run the published workload
+    # executor binaries.
+    powershell.exe '.\integrations\dotnet\dotnet-install.ps1 -Channel 5.0 -InstallDir .dotnet -NoPath'
+    powershell.exe '.\integrations\dotnet\dotnet-install.ps1 -Channel 2.1 -InstallDir .dotnet -NoPath'
+else
+    # Download the dotnet installation script, retrying up to 5 times on any errors.
+    curl -sSL \
+        --max-time 20 \
+        --retry 5 \
+        --retry-delay 0 \
+        --retry-max-time 60 \
+        -o integrations/dotnet/dotnet-install.sh \
+        https://dot.net/v1/dotnet-install.sh
+
+    # Install the v5.0 SDK to build the driver and the v2.1 SDK to run the published workload
+    # executor binaries.
+    bash ./integrations/dotnet/dotnet-install.sh -Channel 5.0 --install-dir .dotnet --no-path
+    bash ./integrations/dotnet/dotnet-install.sh -Channel 2.1 --install-dir .dotnet --no-path
+fi
 
 # /p required to get around https://github.com/dotnet/sdk/issues/12159
-${LOCALAPPDATA}/Microsoft/dotnet/dotnet build mongo-csharp-driver /p:Platform="Any CPU" # platform needs a space when building
-${LOCALAPPDATA}/Microsoft/dotnet/dotnet publish mongo-csharp-driver/tests/AstrolabeWorkloadExecutor \
+./.dotnet/dotnet build mongo-csharp-driver /p:Platform="Any CPU" # platform needs a space when building
+./.dotnet/dotnet publish mongo-csharp-driver/tests/AstrolabeWorkloadExecutor \
     --no-build --no-restore \
     --framework "${FRAMEWORK}" \
     /p:Platform="AnyCpu" # platform does not need a space when publishing

--- a/integrations/dotnet/workload-executor
+++ b/integrations/dotnet/workload-executor
@@ -42,6 +42,6 @@ export PLATFORM
 #     Addditionally, we must use the published version to bypass a dependency resolution issue with .NET Core 1.1
 set +x # hide connection string in test output
 
-dotnet mongo-csharp-driver/tests/AstrolabeWorkloadExecutor/bin/Debug/"${FRAMEWORK}"/publish/workload-executor.dll "${CONNECTION_STRING}" "${WORKLOAD_SPEC}"
+./.dotnet/dotnet mongo-csharp-driver/tests/AstrolabeWorkloadExecutor/bin/Debug/"${FRAMEWORK}"/publish/workload-executor.dll "${CONNECTION_STRING}" "${WORKLOAD_SPEC}"
 
 set -x


### PR DESCRIPTION
[DRIVERS-2419](https://jira.mongodb.org/browse/DRIVERS-2419)

Update the .NET driver install and workload executor scripts to support building and running on Linux. Add an Ubuntu .NET build variant that only runs the Kind test tasks.

Changes:
* Add an .NET Ubuntu build variant that only runs the Kind test tasks.
* Update the `"run kind test"` function to allow overriding the standard connection string for the Kind cluster.
  * Override the standard connection string for the .NET Kind test tasks because .NET doesn't currently support loading TLS certs or CA files from connection string params. Use `tlsInsecure=true` instead.
* Add Windows and Linux driver build and install commands to the .NET `install-driver.sh` script.
  * Move Windows-specific environment variables to the Windows-only block of the .NET driver install script.
* Update the expected `dotnet` executable path in the .NET `workload-executor` script to always use the installed `dotnet` executable on Windows and Linux.
  * Previously the `workload-executor` script on Windows .NET tasks was using a `dotnet` executable that was already installed on the system, which is confusing and doesn't work in Ubuntu tasks. Instead, install both .NET 5.0 for building the workload executor and .NET 2.1 for running it.
* Update `"install driver"` function to run the appropriate shell command for Windows and Linux.
  * Allows removing the `continue_on_err` directive, which masks driver install failures. Subsequent errors will happen if the driver fails to install, but the root cause is much less obvious.