### PR TITLE
DRIVERS-2420 Use a keystore to provide TLS certs to the Java driver.

### DIFF
--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -733,11 +733,7 @@ buildvariants:
     runtime: ["java17"]
   display_name: "${driver} ${platform} ${runtime}"
   tasks:
-    # TODO(DRIVERS-2420): The Kind test runner currently expects drivers to be able to load TLS
-    # secrets from the files specified in the connection string, but the Java driver doesn't support
-    # that. Remove the "!.kind" filter when the Java workload executor is updated to support loading
-    # TLS secrets into a trust store so the Java driver can use them.
-    - ".all !.kind"
+    - ".all"
 - matrix_name: "tests-dotnet-windows"
   matrix_spec:
     driver: ["dotnet-master"]

--- a/integrations/java/sync/install-driver.sh
+++ b/integrations/java/sync/install-driver.sh
@@ -1,11 +1,9 @@
 #!/bin/bash
 
+set -o xtrace
 set -o errexit
-
-export JAVA_HOME="/opt/java/jdk17"
 
 cd mongo-java-driver || exit
 ./gradlew --info driver-workload-executor:shadowJar
 cd ..
 cp mongo-java-driver/driver-workload-executor/build/libs/driver-workload-executor-*.jar driver-workload-executor.jar
-

--- a/integrations/java/sync/workload-executor
+++ b/integrations/java/sync/workload-executor
@@ -1,5 +1,6 @@
 #!/bin/bash
 
+set -o xtrace
 set -o errexit
 
 workloadExecutorFile="/tmp/java-driver-workload-executor.json"
@@ -11,5 +12,37 @@ printf "%s" "$2" > "$workloadExecutorFile"
 
 OUTPUT_DIRECTORY=$PWD
 
-java -Xmx8g -jar -Dorg.mongodb.test.uri="$1" driver-workload-executor.jar $workloadExecutorFile $OUTPUT_DIRECTORY
+# The Java driver doesn't support the "tlsCAFile" connection string param, so if it's present, we
+# need to add that file to a truststore file and set JVM properties to use the truststore.
+CA_FILE=$(sed -En 's/.*tlsCAFile=([^&]+).*/\1/p' <<< "$1")
+if [ ! -z "$CA_FILE" ]; then
+    echo "Found tlsCAFile=$CA_FILE in connection string, adding CA to a trust store."
+    $JAVA_HOME/bin/keytool \
+        -import \
+        -keystore truststore.jks \
+        -trustcacerts \
+        -file "$CA_FILE" \
+        -storepass 123456 \
+        -noprompt
+    TRUSTSTORE_OPTS="-Djavax.net.ssl.trustStore=$(pwd)/truststore.jks -Djavax.net.ssl.trustStorePassword=123456"
+fi
 
+# The Java driver doesn't support the "tlsCertificateKeyFile" connection string param, so if it's
+# present, we need to add that file to a keystore file and set JVM properties to use the keystore.
+CERT_FILE=$(sed -En 's/.*tlsCertificateKeyFile=([^&]+).*/\1/p' <<< "$1")
+if [ ! -z "$CERT_FILE" ]; then
+    echo "Found tlsCertificateKeyFile=$CERT_FILE in connection string, adding cert to a key store."
+    $JAVA_HOME/bin/keytool \
+        -importcert \
+        -keystore keystore.jks \
+        -file "$CERT_FILE" \
+        -storepass 123456 \
+        -noprompt
+    KEYSTORE_OPTS="-Djavax.net.ssl.keyStore=$(pwd)/keystore.jks -Djavax.net.ssl.keyStorePassword=123456"
+fi
+
+$JAVA_HOME/bin/java -Xmx8g -jar \
+    -Dorg.mongodb.test.uri="$1" \
+    $TRUSTSTORE_OPTS \
+    $KEYSTORE_OPTS \
+    driver-workload-executor.jar $workloadExecutorFile $OUTPUT_DIRECTORY


### PR DESCRIPTION
[DRIVERS-2420](https://jira.mongodb.org/browse/DRIVERS-2420)

The Java driver does not support the `tlsCertificateKeyFile` and `tlsCAFile` connection string parameters (see [JAVA-3066](https://jira.mongodb.org/browse/JAVA-3066)) and instead uses a "key store" to provide TLS certs and CAs to the JVM. Update the Java workload executor script to check for the `tlsCertificateKeyFile` and `tlsCAFile` connection string parameters and, if present, add them to key stores and point the JVM at those key stores.