### PR TITLE
Update .NET build SDK version to 6.0

### DIFF
--- a/integrations/dotnet/install-driver.sh
+++ b/integrations/dotnet/install-driver.sh
@@ -26,9 +26,9 @@ if [[ "$OS" =~ Windows|windows ]]; then
         -o integrations/dotnet/dotnet-install.ps1 \
         https://dot.net/v1/dotnet-install.ps1
 
-    # Install the v5.0 SDK to build the driver and the v2.1 SDK to run the published workload
+    # Install the v6.0 SDK to build the driver and the v2.1 SDK to run the published workload
     # executor binaries.
-    powershell.exe '.\integrations\dotnet\dotnet-install.ps1 -Channel 5.0 -InstallDir .dotnet -NoPath'
+    powershell.exe '.\integrations\dotnet\dotnet-install.ps1 -Channel 6.0 -InstallDir .dotnet -NoPath'
     powershell.exe '.\integrations\dotnet\dotnet-install.ps1 -Channel 2.1 -InstallDir .dotnet -NoPath'
 else
     # Download the dotnet installation script, retrying up to 5 times on any errors.
@@ -40,9 +40,9 @@ else
         -o integrations/dotnet/dotnet-install.sh \
         https://dot.net/v1/dotnet-install.sh
 
-    # Install the v5.0 SDK to build the driver and the v2.1 SDK to run the published workload
+    # Install the v6.0 SDK to build the driver and the v2.1 SDK to run the published workload
     # executor binaries.
-    bash ./integrations/dotnet/dotnet-install.sh -Channel 5.0 --install-dir .dotnet --no-path
+    bash ./integrations/dotnet/dotnet-install.sh -Channel 6.0 --install-dir .dotnet --no-path
     bash ./integrations/dotnet/dotnet-install.sh -Channel 2.1 --install-dir .dotnet --no-path
 fi
 


### PR DESCRIPTION
The .NET driver started failing recently (e.g. [here](https://evergreen.mongodb.com/lobster/evergreen/task/drivers_atlas_testing_tests_dotnet_linux__driver~dotnet_master_platform~ubuntu_18.04_runtime~dotnet_async_netcoreapp2.1_kind_reads_baseline_631825530305b9103d6b7d46_22_09_07_05_00_03/0/task#bookmarks=0%2C206&l=1)) with an error message like:
```
error NETSDK1045: The current .NET SDK does not support targeting .NET 6.0.  Either target .NET 5.0 or lower, or use a version of the .NET SDK that supports .NET 6.0. [/mongo-csharp-driver/tests/MongoDB.Bson.Tests/MongoDB.Bson.Tests.csproj]
```
It seems to be related to https://github.com/mongodb/mongo-csharp-driver/pull/873, which updates the target framework for the `MongoDB.Bson.Tests.csproj` file.

Update the .NET build script to download v6.0 instead of v5.0