### PR TITLE
DRIVERS-2363 Mark all Atlas test setup exceptions as 'cloud-failure'.

### DIFF
--- a/astrolabe/atlas_runner.py
+++ b/astrolabe/atlas_runner.py
@@ -283,16 +283,10 @@ class AtlasTestCase:
                 self.failed = True
                 # Write xunit logs for failed tests.
                 junit_test.result = junitparser.Failure(str(stats))
-                
-                with open('status', 'w') as fp:
-                    fp.write('failure')
             else:
                 LOGGER.info("SUCCEEDED: {!r}".format(self.id))
                 # Directly log output of successful tests as xunit output
                 # is only visible for failed tests.
-                
-                with open('status', 'w') as fp:
-                    fp.write('success')
 
             LOGGER.info("Workload Statistics: {}".format(stats))
             
@@ -476,20 +470,6 @@ class SpecTestRunnerBase:
             tablefmt="rst"))
 
     def run(self):
-        try:
-            return self.do_run()
-        except (PollingTimeoutError, AtlasApiError):
-            with open('status', 'w') as fp:
-                fp.write('cloud-failure')
-            raise
-        except AtlasClientError as exc:
-            # Intermittent atlas problem, see DRIVERS-2012.
-            if 'Max retries exceeded' in str(exc):
-                with open('status', 'w') as fp:
-                    fp.write('cloud-failure')
-            raise
-
-    def do_run(self):
         # Step-0: sentinel flag to track failure/success.
         all_ok = True
 
@@ -527,12 +507,6 @@ class SpecTestRunnerBase:
                 all_ok = False
 
             print('done: %s, %s, %s' % (active_case.failed,ok,all_ok))
-                
-        with open('status', 'w') as fp:
-            if all_ok:
-                fp.write('success')
-            else:
-                fp.write('failure')
 
         return not all_ok
 


### PR DESCRIPTION
[DRIVERS-2363](https://jira.mongodb.org/browse/DRIVERS-2363)

Currently, some exceptions that can happen during the Atlas test environment setup are not marked as a setup failure and instead show up as a test failure. The cause is that the `SingleTestRunner` constructor performs a bunch of Atlas cluster provisioning work as well as the `run()` method, but the constructor has no exception handling. To resolve that, move all Atlas "run-one" exception handling and "status" file writing into `cli.py`, and add exception handling to calling the `SingleTestRunner` constructor.

Changes:
* Catch all exceptions that happen while calling the `SingleTestRunner` constructor and mark them as "cloud-failure".
* Move all Atlas "run-one" exception handling into `cli.py` instead of `atlas_runner.py`.
* Move all "status" file writing into `cli.py` instead of `atlas_runner.py`.

Tested in [this patch](https://spruce.mongodb.com/version/6319204a32f4177cd961e998/tasks?sorts=STATUS%3AASC%3BBASE_STATUS%3ADESC) and seems successful.