### PR TITLE
DRIVERS-2434 Fix Ruby Driver unified spec test runner integration.

### DIFF
--- a/integrations/ruby/executor.rb
+++ b/integrations/ruby/executor.rb
@@ -23,7 +23,7 @@ class Executor
     set_signal_handler
     begin
       unified_tests.each do |test|
-        test.create_entities
+        test.create_spec_entities
         test.set_initial_data
         @test_running = true
         begin


### PR DESCRIPTION
[DRIVERS-2434](https://jira.mongodb.org/browse/DRIVERS-2434)

https://github.com/mongodb/mongo-ruby-driver/pull/2598 renamed the Ruby Driver unified test runner method `create_entities` to `create_spec_entities`. Update the call in the Ruby workload executor to use the new method name.

Note that https://github.com/mongodb/mongo-ruby-driver/pull/2619 will fix the other outstanding Ruby integration failures.