### PR TITLE
DRIVERS-2263 Add a Kind test case for server version upgrade.

### DIFF
--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -540,6 +540,26 @@ tasks:
           TEST_FILE: tests/kubernetes/kind/deletePod.yml
           WORKLOAD_FILE: workloads/reads.yml
           KIND: "true"
+  - name: kind-retryReads-upgrade
+    tags: ["all", "kind"]
+    commands:
+      - func: "download kubernetes tools"
+      - func: "create kind cluster"
+      - func: "run kind test"
+        vars:
+          TEST_FILE: tests/kubernetes/kind/upgrade.yml
+          WORKLOAD_FILE: workloads/reads.yml
+          KIND: "true"
+  - name: kind-retryWrites-upgrade
+    tags: ["all", "kind"]
+    commands:
+      - func: "download kubernetes tools"
+      - func: "create kind cluster"
+      - func: "run kind test"
+        vars:
+          TEST_FILE: tests/kubernetes/kind/upgrade.yml
+          WORKLOAD_FILE: workloads/writes.yml
+          KIND: "true"
 
 axes:
   # The 'driver' axis specifies the driver to be tested (including driver version).

--- a/tests/kubernetes/kind/upgrade.yml
+++ b/tests/kubernetes/kind/upgrade.yml
@@ -1,0 +1,12 @@
+# Upgrade the MongoDB server version from 5.0.8 to 5.0.12. That will cause a rolling deploy where
+# each pod is terminated and recreated with the new server version. This process typically takes
+# between 5 and 10 minutes for a 3-node replica set.
+# This test case is used to assert that reads and writes can continue when a rolling deploy of the
+# MongoDB replica set happens.
+operations:
+  - kubectl: [--namespace, default, patch, MongoDBCommunity, mongodb, --type=merge, -p, '{"spec":{"version":"5.0.12"}}']
+  # It can take a few seconds for the MongoDBCommunity resource to switch from "Running" back to
+  # "Pending" after patching the resource, so sleep for 10 seconds before checking the status.
+  - sleep: 10
+  - kubectl: [--namespace, default, wait, MongoDBCommunity/mongodb, --for, "jsonpath={.status.phase}=Running", --timeout=15m]
+  - sleep: 5

--- a/workloads/reads.yml
+++ b/workloads/reads.yml
@@ -60,3 +60,10 @@ tests:
                   x: 22
                 - _id: 3
                   x: 33
+            # Introduce some latency in the find loop to prevent the number of recorded events from
+            # becoming too large, especially for local Kind deployments that have a very short round
+            # trip time.
+            - name: find
+              object: *collection0
+              arguments:
+                filter: { $where: 'sleep(50)' }

--- a/workloads/writes.yml
+++ b/workloads/writes.yml
@@ -42,7 +42,14 @@ tests:
           storeIterationsAsEntity: iterations
           storeSuccessesAsEntity: successes
           operations:
-          - name: insertOne
-            object: *collection0
-            arguments:
-              document: { data: 100 }
+            - name: insertOne
+              object: *collection0
+              arguments:
+                document: { data: 100 }
+            # Introduce some latency in the insert loop to prevent the number of recorded events
+            # from becoming too large, especially for local Kind deployments that have a very short
+            # round trip time.
+            - name: find
+              object: *collection0
+              arguments:
+                filter: { $where: 'sleep(50)' }


### PR DESCRIPTION
[DRIVERS-2263](https://jira.mongodb.org/browse/DRIVERS-2263)

Add a Kind test case that upgrades the server version from 5.0.8 to 5.0.12. Assert that reads and writes (with retry enabled) can continue successfully during the upgrade.

Also add some delay to the read and write loops so that the number of events collected doesn't become unreasonably large, especially for the local Kind cluster where the round trip time is very short.