### PR TITLE
DRIVERS-2263 Add comments describing the required server versions for the 'upgrade' test.

### DIFF
--- a/kubernetes/kind/mongodb.yml
+++ b/kubernetes/kind/mongodb.yml
@@ -18,6 +18,9 @@ metadata:
 spec:
   members: 3
   type: ReplicaSet
+  # Note that the "upgrade" Kind test scenario depends on the server version here being 5.0.8. If we
+  # update the server version here, we must also update the server version used in the "patch"
+  # command in "tests/kubernetes/kind/upgrade.yml".
   version: "5.0.8"
   replicaSetHorizons:
   - local: localhost:31181

--- a/tests/kubernetes/kind/upgrade.yml
+++ b/tests/kubernetes/kind/upgrade.yml
@@ -4,6 +4,9 @@
 # This test case is used to assert that reads and writes can continue when a rolling deploy of the
 # MongoDB replica set happens.
 operations:
+  # Note that this server version upgrade command assumes that the "mongodb" cluster is created with
+  # server version 5.0.8, which is defined in "kubernetes/kind/mongodb.yml". If the server version in
+  # that config file changes, this upgrade version must be updated as well.
   - kubectl: [--namespace, default, patch, MongoDBCommunity, mongodb, --type=merge, -p, '{"spec":{"version":"5.0.12"}}']
   # It can take a few seconds for the MongoDBCommunity resource to switch from "Running" back to
   # "Pending" after patching the resource, so sleep for 10 seconds before checking the status.


### PR DESCRIPTION
[DRIVERS-2263](https://jira.mongodb.org/browse/DRIVERS-2263)

The Kind "upgrade" test added in https://github.com/mongodb-labs/drivers-atlas-testing/pull/150 depends on the "base" server version used in the Kind cluster being 5.0.8. Add comments that describe the link between the server version used in the Kind "upgrade" test [here](https://github.com/mongodb-labs/drivers-atlas-testing/blob/329efdddd568e486d5f2a8c60b5a9db5067db0df/tests/kubernetes/kind/upgrade.yml#L7) and the server version used in the "base" Kind cluster [here](https://github.com/mongodb-labs/drivers-atlas-testing/blob/329efdddd568e486d5f2a8c60b5a9db5067db0df/kubernetes/kind/mongodb.yml#L21).