### PR TITLE
Add the relevant NODE ticket to the TODO comment for re-enabling the Node integration.

### DIFF
--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -732,8 +732,8 @@ buildvariants:
   tasks:
     # Kind tasks can't run on Windows, so exclude them.
     - ".all !.kind"
-# TODO: re-enable language builds once workload executors have been
-# re-implemented to work with the new format
+# TODO(NODE-3049): Re-enable Node builds once the Node driver and/or workload executor have been
+# updated to be able to run the new unified-format tests.
 #- matrix_name: tests-node
 #  matrix_spec:
 #    driver:


### PR DESCRIPTION
The work to re-enable the Node integration is tracked in [NODE-3049](https://jira.mongodb.org/browse/NODE-3049). Add that ticket number to the `TODO` comment for re-enabling the Node integration in the Evergreen config.