### PR TITLE
DRIVERS-2263 Add a Kind test case for replica set scale down.

### DIFF
--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -558,6 +558,28 @@ tasks:
           WORKLOAD_FILE: workloads/writes.yml
       - func: "retrieve kind logs"
       - func: "delete kind cluster"
+  - name: kind-retryReads-scaleDown
+    tags: ["all", "kind"]
+    commands:
+      - func: "download kubernetes tools"
+      - func: "create kind cluster"
+      - func: "run kind test"
+        vars:
+          TEST_FILE: tests/kubernetes/kind/scaleDown.yml
+          WORKLOAD_FILE: workloads/reads.yml
+      - func: "retrieve kind logs"
+      - func: "delete kind cluster"
+  - name: kind-retryWrites-scaleDown
+    tags: ["all", "kind"]
+    commands:
+      - func: "download kubernetes tools"
+      - func: "create kind cluster"
+      - func: "run kind test"
+        vars:
+          TEST_FILE: tests/kubernetes/kind/scaleDown.yml
+          WORKLOAD_FILE: workloads/writes.yml
+      - func: "retrieve kind logs"
+      - func: "delete kind cluster"
 
 axes:
   # The 'driver' axis specifies the driver to be tested (including driver version).

--- a/tests/kubernetes/kind/scaleDown.yml
+++ b/tests/kubernetes/kind/scaleDown.yml
@@ -1,0 +1,14 @@
+# Scale down the MongoDB replica set from 3 nodes to 1 node.
+# This test case is used to assert that reads and writes can continue when a scale-down operation
+# happens.
+operations:
+  # Note that this scale-down command assumes that the "mongodb" cluster is created with 3 replica
+  # set nodes, which is defined by the "members" value in "kubernetes/kind/mongodb.yml". If the
+  # number of replica set nodes in that config file changes, this scale-down command must be updated
+  # as well.
+  - kubectl: [--namespace, default, patch, MongoDBCommunity, mongodb, --type=merge, -p, '{"spec":{"members":1}}']
+  # It can take a few seconds for the MongoDBCommunity resource to switch from "Running" back to
+  # "Pending" after patching the resource, so sleep for 10 seconds before checking the status.
+  - sleep: 10
+  - kubectl: [--namespace, default, wait, MongoDBCommunity/mongodb, --for, "jsonpath={.status.phase}=Running", --timeout=15m]
+  - sleep: 5


### PR DESCRIPTION
[DRIVERS-2263](https://jira.mongodb.org/browse/DRIVERS-2263)

Add a Kind test case that scales the number of replica set nodes from 3 to 1. Assert that reads and writes (with retry enabled) can continue successfully during the scale-down.