### PR TITLE
CLOUDP-123702: Increase Atlas http timeout to 30 sec and handle group cleanup exception

### DIFF
--- a/astrolabe/atlas_runner.py
+++ b/astrolabe/atlas_runner.py
@@ -483,8 +483,15 @@ class SpecTestRunnerBase:
                     project_timestamp = project.name.split('-')[-1]
                 if project_timestamp.isnumeric() and \
                     int(project_timestamp) < current_timestamp - self.project_expiration_threshold_seconds:
-                    delete_project(client=self.client, project_id=project.id)
-                    LOGGER.info("Successfully deleted project {!r}, id: {!r}".format(project.name, project.id)) 
+                    try:
+                        delete_project(client=self.client, project_id=project.id)
+                        LOGGER.info("Successfully deleted project {!r}, id: {!r}".format(project.name, project.id)) 
+                    except AtlasApiError as esc:
+                        # the project may have been deleted by another test just now.
+                        if esc.error_code == 'GROUP_NOT_FOUND':
+                            LOGGER.warn(esc)
+                        else:
+                            raise
 
     def get_printable_test_plan(self):
         table_data = []

--- a/atlasclient/configuration.py
+++ b/atlasclient/configuration.py
@@ -26,6 +26,6 @@ ClientConfiguration = namedtuple(
 
 # Default configuration values.
 CONFIG_DEFAULTS = JSONObject.from_dict({
-    "ATLAS_HTTP_TIMEOUT": 10.0,
+    "ATLAS_HTTP_TIMEOUT": 30.0,
     "ATLAS_API_VERSION": "atlas/v1.0",
     "ATLAS_API_BASE_URL": "https://cloud.mongodb.com/api"})


### PR DESCRIPTION
[CLOUDP-123702](https://jira.mongodb.org/browse/CLOUDP-123702)

This addresses the two remaining failure cases relevant to the original ticket.

Group not found during clean_old_projects:
https://evergreen.mongodb.com/task/drivers_atlas_testing_tests_ruby__driver~ruby_master_platform~ubuntu_18.04_runtime~python39_atlas_retryReads_primaryTakeover_633a6c54d6d80a2daf4a35b1_22_10_03_05_00_04

And http timeout while ensuring project:
https://evergreen.mongodb.com/task/drivers_atlas_testing_tests_python_windows__driver~pymongo_master_platform~windows_64_runtime~python37_windows_atlas_retryReads_move_sharded_63391ad1c9ec443c49aa2150_22_10_02_05_00_01

