### PR TITLE
Fix RST syntax

### DIFF
--- a/workloads/README.rst
+++ b/workloads/README.rst
@@ -4,8 +4,7 @@ Workloads
 The YAML files in this directory are *Workload* files that describe a set of
 operations that the workload executor (i.e. the MongoDB driver under test) will
 run while connected to the MongoDB cluster in Kubernetes. The documents use the
-MongoDB driver`Unified Test Format
-<https://github.com/mongodb/specifications/blob/master/source/unified-test-format/unified-test-format.rst>`_
+MongoDB driver `Unified Test Format <https://github.com/mongodb/specifications/blob/master/source/unified-test-format/unified-test-format.rst>`_
 YAML file format. See the `Test Format Specification
 <https://mongodb-labs.github.io/drivers-atlas-testing/spec-test-format.html>`_
 for a detailed description of the file format.


### PR DESCRIPTION
Fixes broken syntax introduced in https://github.com/mongodb-labs/drivers-atlas-testing/commit/74c1c750f4941c690cf41773af16ad95dd957bbd.