### PR TITLE
Catch and retry HTTP timeouts that happen while polling for cluster state.

### DIFF
--- a/astrolabe/atlas_runner.py
+++ b/astrolabe/atlas_runner.py
@@ -338,7 +338,14 @@ class AtlasTestCase:
         wanted_state = 'idle'
         last_notified = 0
         while timer.elapsed < timeout:
-            cluster_info = self.cluster_url.get().data
+            sleep(1.0 / self.config.polling_frequency)
+
+            try:
+                cluster_info = self.cluster_url.get().data
+            except AtlasClientError as e:
+                LOGGER.error(f"Error getting cluster status: {e}")
+                continue
+
             actual_state = cluster_info.stateName.lower()
             if actual_state == wanted_state:
                 ok = True
@@ -352,8 +359,6 @@ class AtlasTestCase:
                 LOGGER.info(msg)
             else:
                 LOGGER.debug(msg)
-            
-            sleep(1.0 / self.config.polling_frequency)
         if not ok:
             raise PollingTimeoutError("Polling timed out after %s seconds" % timeout)
             


### PR DESCRIPTION
Sometimes the `astrolabe` CLI will exit when polling for Atlas cluster status due to an HTTP call timeout. An example exception output is:
```
atlasclient.exceptions.AtlasClientError: HTTPSConnectionPool(host='cloud-qa.mongodb.com', port=443): Read timed out. (read timeout=30.0) (GET https://cloud-qa.mongodb.com/api/atlas/v1.0/groups/639e9f7f25930c386c4e5ad3/clusters/4ba448af53)
```

Those HTTP call timeouts seem to be intermittent, so we should retry the call again instead of allowing the CLI to exit.