### PR TITLE
Switched Astrolabe to run on .NET 6.

### DIFF
--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -716,16 +716,16 @@ axes:
         display_name: Java 17
         variables:
           JAVA_HOME: "/opt/java/jdk17"
-      - id: dotnet-async-netcoreapp2.1
-        display_name: dotnet-async-netcoreapp2.1
+      - id: dotnet-async-net6
+        display_name: dotnet-async-net6
         variables:
           ASYNC: "true"
-          FRAMEWORK: "netcoreapp2.1"
-      - id: "dotnet-sync-netcoreapp2.1"
-        display_name: dotnet-sync-netcoreapp2.1
+          FRAMEWORK: "net6.0"
+      - id: dotnet-sync-net6
+        display_name: dotnet-sync-net6
         variables:
           ASYNC: "false"
-          FRAMEWORK: "netcoreapp2.1"
+          FRAMEWORK: "net6.0"
       - id: go-20
         display_name: Go v1.20
         variables:
@@ -801,8 +801,8 @@ buildvariants:
     driver: ["dotnet-master"]
     platform: ["windows-64"]
     runtime:
-      - "dotnet-async-netcoreapp2.1"
-      - "dotnet-sync-netcoreapp2.1"
+      - "dotnet-async-net6"
+      - "dotnet-sync-net6"
   display_name: "${driver} ${platform} ${runtime}"
   tasks:
     # Kind tasks can't run on Windows, so exclude them.
@@ -812,8 +812,8 @@ buildvariants:
     driver: ["dotnet-master"]
     platform: ["ubuntu-18.04"]
     runtime:
-      - "dotnet-async-netcoreapp2.1"
-      - "dotnet-sync-netcoreapp2.1"
+      - "dotnet-async-net6"
+      - "dotnet-sync-net6"
   display_name: "${driver} ${platform} ${runtime}"
   tasks:
     # Only run the Kind tasks for the .NET driver on Linux.

--- a/integrations/dotnet/install-driver.sh
+++ b/integrations/dotnet/install-driver.sh
@@ -3,7 +3,7 @@ set -o xtrace   # Write all commands first to stderr
 set -o errexit  # Exit the script with error if any of the commands fail
 
 # Environment variables used as input:
-#   FRAMEWORK                       Set to specify .NET framework to test against. Values: "netcoreapp2.1"
+#   FRAMEWORK                       Set to specify .NET framework to test against. Values: "net6.0"
 
 export DOTNET_SKIP_FIRST_TIME_EXPERIENCE=1
 export DOTNET_CLI_TELEMETRY_OPTOUT=1
@@ -26,10 +26,7 @@ if [[ "$OS" =~ Windows|windows ]]; then
         -o integrations/dotnet/dotnet-install.ps1 \
         https://dot.net/v1/dotnet-install.ps1
 
-    # Install the v6.0 SDK to build the driver and the v2.1 SDK to run the published workload
-    # executor binaries.
     powershell.exe '.\integrations\dotnet\dotnet-install.ps1 -Channel 6.0 -InstallDir .dotnet -NoPath'
-    powershell.exe '.\integrations\dotnet\dotnet-install.ps1 -Channel 2.1 -InstallDir .dotnet -NoPath'
 else
     # Download the dotnet installation script, retrying up to 5 times on any errors.
     curl -sSL \
@@ -40,10 +37,7 @@ else
         -o integrations/dotnet/dotnet-install.sh \
         https://dot.net/v1/dotnet-install.sh
 
-    # Install the v6.0 SDK to build the driver and the v2.1 SDK to run the published workload
-    # executor binaries.
     bash ./integrations/dotnet/dotnet-install.sh -Channel 6.0 --install-dir .dotnet --no-path
-    bash ./integrations/dotnet/dotnet-install.sh -Channel 2.1 --install-dir .dotnet --no-path
 fi
 
 # /p required to get around https://github.com/dotnet/sdk/issues/12159

--- a/integrations/dotnet/workload-executor
+++ b/integrations/dotnet/workload-executor
@@ -3,13 +3,13 @@
 set -o errexit  # Exit the script with error if any of the commands fail
 
 # Environment variables used as input:
-#   FRAMEWORK                       Set to specify .NET framework to test against. Values: "netcoreapp2.1"
+#   FRAMEWORK                       Set to specify .NET framework to test against. Values: "net6.0"
 #   ASYNC                           Whether or not to use async operations (which may be run synchronously). Values: true, false
 # Environment variables produced as output:
 #   RESULTS_DIR                     Where to output results.json
 #   ASYNC                           Whether or not to use async operations (which may be run synchronously). Values: true, false
 
-FRAMEWORK=${FRAMEWORK:-netcoreapp2.1}
+FRAMEWORK=${FRAMEWORK:-net6.0}
 ASYNC=${ASYNC:-true}
 
 ############################################


### PR DESCRIPTION
.NET Core 2.x is EOL and Microsoft removed the binaries from the download location. Switching to .NET 6 since it is an LTS release.

WARNING: I was unsuccessful in running `astrolabe` locally. So these changes are currently untested. If there are any issues, please let me know and I can investigate.