### PR TITLE
DRIVERS-1660 Remove assertions for types of workload executor events

### DIFF
--- a/astrolabe/validator.py
+++ b/astrolabe/validator.py
@@ -171,34 +171,12 @@ class ValidateWorkloadExecutor(TestCase):
             if not events['events']:
                 self.fail("The workload executor recorded no events but some were expected")
 
-            numConnectionEvents = 0
-            numPoolEvents = 0
-            numCommandEvents = 0
-
             for event in events['events']:
                 if ('name' not in event) or (not event['name'].endswith('Event')):
                     self.fail("The workload executor didn't record event name as expected.")
 
                 if 'observedAt' not in event:
                     self.fail("The workload executor didn't record event observation time as expected.")
-
-                if event['name'].startswith('Connection'):
-                    numConnectionEvents += 1
-
-                if event['name'].startswith('Pool'):
-                    numPoolEvents += 1
-
-                if event['name'].startswith('Command'):
-                    numCommandEvents += 1
-
-            if numConnectionEvents == 0:
-                self.fail("The workload executor recorded no CMAP connection events but some were expected")
-
-            if numPoolEvents == 0:
-                self.fail("The workload executor recorded no CMAP connection pool events but some were expected")
-
-            if numCommandEvents == 0:
-                self.fail("The workload executor recorded no command monitoring events but some were expected")
         else:
             if events['events']:
                 self.fail("The workload executor recorded %d events but none were expected" % len(events['events']))

--- a/astrolabe/validator.py
+++ b/astrolabe/validator.py
@@ -164,9 +164,6 @@ class ValidateWorkloadExecutor(TestCase):
         # If hasEvents is true, assert that the array is non-empty and that each
         # object within contains essential fields. If hasEvents is false, the
         # array should be empty.
-        #
-        # Note: we do not assert the type of events observed since not all
-        # drivers implement CMAP and thus might only log Command events.
         if hasEvents:
             if not events['events']:
                 self.fail("The workload executor recorded no events but some were expected")


### PR DESCRIPTION
The [documentation](https://github.com/mongodb-labs/drivers-atlas-testing/blob/3d5a29150e463ecb58179912ef24729b541a9347/astrolabe/validator.py#L130) for `assert_events` states:

> Based on the corresponding parameter for each field, the function will then assert either that the array is empty or that it is non-empty and each document therein has an expected structure.

And [within the function](https://github.com/mongodb-labs/drivers-atlas-testing/blob/3d5a29150e463ecb58179912ef24729b541a9347/astrolabe/validator.py#L164):

> If hasEvents is true, assert that the array is non-empty and that each object within contains essential fields. If hasEvents is false, the array should be empty.
>
> Note: we do not assert the type of events observed since not all drivers implement CMAP and thus might only log Command events.

Both suggest only the _structure_ of the `events` array is validated and whether the array is _empty or non-empty_. However, despite the note suggesting "we do not assert the type of events observed", the function currently individually asserts for the presence of at least one CMAP connection, CMAP connection pool, and command monitoring event.

This PR proposes removing these assertions for consistency with documented behavior: "assert either that the array is empty or that it is non-empty" (+ structure assertions, left unchanged). This will also allow Drivers that have not implemented CMAP to implement Atlas Testing integrations without requiring [faking CMAP events](https://github.com/mongodb-labs/drivers-atlas-testing/blob/3d5a29150e463ecb58179912ef24729b541a9347/integrations/php/workload-executor.php#L26) to satisfy the validator's current CMAP event expectations.

This PR is also an opportunity to question/revisit why these events are being individually asserted. Is specifically distinguishing CMAP connection, CMAP pool connection, and command monitoring events (as opposed to the presence of _any_ recorded events) necessary to ensuring correct Atlas Testing behavior? Shouldn't the presence of expected events (and absence of unwanted events) be controlled by the [test specification files](https://github.com/mongodb-labs/drivers-atlas-testing/blob/b69c43e1f5c24f717deab4ce2255cf683ba0973d/tests/validator-simple.yml#L11) via `storeEventsAsEntities` instead of the validator?