### PR TITLE
CDRIVER-3869 Add C Driver Integration

### DIFF
--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -672,6 +672,12 @@ axes:
           DRIVER_REPOSITORY: "https://github.com/mongodb/mongo-rust-driver"
           DRIVER_REVISION: "main"
           ASTROLABE_EXECUTOR_STARTUP_TIME: 10
+      - id: c-master
+        display_name: "C (master)"
+        variables:
+          DRIVER_DIRNAME: "c"
+          DRIVER_REPOSITORY: "https://github.com/mongodb/mongo-c-driver"
+          DRIVER_REVISION: "master"
 
   # The 'platform' axis specifies the evergreen host distro to use.
   # Platforms MUST specify the PYTHON3_BINARY variable as this is required to install astrolabe.
@@ -746,6 +752,17 @@ axes:
           PHP_VERSION: 7.4
       - id: rust-latest
         display_name: Rust Latest
+      - id: "c-clang"
+        display_name: Clang
+        variables:
+          CC: /opt/mongodbtoolchain/v4/bin/clang
+          CXX: /opt/mongodbtoolchain/v4/bin/clang++
+          ASAN_SYMBOLIZER_PATH: /opt/mongodbtoolchain/v4/bin/llvm-symbolizer
+      - id: "c-gcc"
+        display_name: GCC
+        variables:
+          CC: /opt/mongodbtoolchain/v4/bin/gcc
+          CXX: /opt/mongodbtoolchain/v4/bin/g++
 
 buildvariants:
 - matrix_name: "tests-ruby"
@@ -842,3 +859,10 @@ buildvariants:
   display_name: "${driver} ${platform} ${runtime}"
   tasks:
    - ".all"
+- matrix_name: "tests-c"
+  display_name: "${driver} ${platform} ${runtime}"
+  matrix_spec:
+    driver: ["c-master"]
+    platform: ["ubuntu-18.04"]
+    runtime: ["c-gcc", "c-clang"]
+  tasks: [".all"]

--- a/integrations/c/install-driver.sh
+++ b/integrations/c/install-driver.sh
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+
+echo "Running C Driver install-driver.sh..."
+
+# Defined by .evergreen/config.yml.
+echo "CC: ${CC:?}"
+echo "CXX: ${CXX:?}"
+
+# Ensure required binaries are present.
+command -V "${CC}" >/dev/null || exit
+command -V "${CXX}" >/dev/null || exit
+
+# Cloned by .evergreen/config.yml.
+pushd mongo-c-driver || exit
+
+declare c_install_dir
+c_install_dir="$(pwd)/install-dir" || exit
+
+# Obtain latest CMake binary via C Driver Evergreen testing scripts.
+# shellcheck source=/dev/null
+. "$(pwd)/.evergreen/scripts/find-cmake-latest.sh" || exit
+declare cmake_binary
+cmake_binary="$(find_cmake_latest)" || exit
+command -V "${cmake_binary}" >/dev/null || exit
+
+# /opt/mongodbtoolchain/v4/bin/ninja is buggy:
+#     ninja: error: manifest 'build.ninja' still dirty after 100 tries
+# Use GNU Make and specify build parallelism manually instead.
+declare jobs
+jobs="$(nproc)" || exit
+
+declare -a cmake_config_vars=(
+  "-DCMAKE_BUILD_TYPE=RelWithDebInfo"
+  "-DCMAKE_INSTALL_PREFIX=${c_install_dir}"
+  "-DENABLE_AUTOMATIC_INIT_AND_CLEANUP=OFF"
+)
+
+# Unable to compile with ASAN/UBSAN using GCC on ubuntu1804-drivers-atlas-testing.
+if [[ "${CC}" =~ clang ]]; then
+  cmake_config_vars+=("-DMONGO_SANITIZE=address,undefined")
+  cmake_config_vars+=("-DENABLE_SASL=OFF") # Interferes with LSAN.
+fi
+
+"${cmake_binary}" "${cmake_config_vars[@]}" || exit
+"${cmake_binary}" --build . --target test-atlas-executor -- -j "${jobs}" || exit
+
+popd || exit # mongo-c-driver
+
+echo "Running C Driver install-driver.sh... done!"

--- a/integrations/c/workload-executor
+++ b/integrations/c/workload-executor
@@ -1,0 +1,62 @@
+#!/usr/bin/env bash
+
+echo "Running C Driver workload-executor..."
+
+declare script_dir
+script_dir="$(pwd)" || exit
+declare -r script_dir
+
+declare -r connection_string="${1:?}"
+declare -r workload_spec="${2:?}"
+
+# Populated via install-driver.sh.
+pushd mongo-c-driver || exit
+
+declare test_binary
+test_binary="$(pwd)/src/libmongoc/test-atlas-executor" || exit
+
+# Ensure required binary is present.
+command -V "${test_binary}" >/dev/null || exit
+
+export ASAN_OPTIONS="abort_on_error=1:symbolize=1"
+export UBSAN_OPTIONS="abort_on_error=1:print_stacktrace=1"
+export LSAN_OPTIONS="suppressions=.lsan-suppressions"
+
+export MONGOC_TEST_ATLAS="ON"
+export MONGOC_TEST_URI="${connection_string}"
+
+# Normally test-atlas-executor should always succeed and report failures/errors via generated files.
+# However, if it failed to do so (e.g. due to an assertion failure), communicate execution failure to astrolabe directly.
+if ! "${test_binary}" "${workload_spec}"; then
+  cat >|events.json <<DOC
+{
+  "events": [],
+  "errors": [{"error": "test-atlas-executor encountered an unexpected error", "time": 0}],
+  "failures": []
+}
+DOC
+
+  cat >|results.json <<DOC
+{
+  "numErrors": 1,
+  "numFailures": 0,
+  "numIterations": 0,
+  "numSuccesses": 0
+}
+DOC
+fi
+
+# Print stacktraces if any.
+# shellcheck disable=SC2016
+find . -type f -name '*.core' -print0 |
+  xargs -0 -I {} \
+    bash -c 'echo "backtrace full" | gdb -q -iex "set auto-load safe-path" "${test_binary}" "{}"'
+
+# Generated files are expected to be placed in original directory.
+# Use jq to improve readability of generated JSON.
+jq . events.json >|"${script_dir}/events.json" || exit
+jq . results.json >|"${script_dir}/results.json" || exit
+
+popd || exit # mongo-c-driver
+
+echo "Running C Driver workload-executor... done!"

--- a/integrations/c/workload-executor
+++ b/integrations/c/workload-executor
@@ -54,8 +54,10 @@ find . -type f -name '*.core' -print0 |
 
 # Generated files are expected to be placed in original directory.
 # Use jq to improve readability of generated JSON.
+echo "Formatting events.json and results.json..."
 jq . events.json >|"${script_dir}/events.json" || exit
 jq . results.json >|"${script_dir}/results.json" || exit
+echo "Formatting events.json and results.json... done."
 
 popd || exit # mongo-c-driver
 


### PR DESCRIPTION
## Description

This PR adds integration files to support testing with the [C Driver](https://github.com/mongodb/mongo-c-driver).

Addresses [CDRIVER-3869](https://jira.mongodb.org/browse/CDRIVER-3869) and is related to https://github.com/mongodb/mongo-c-driver/pull/1220.

Verified by [this patch](https://spruce.mongodb.com/version/640f8e347742aee833e8e489/tasks).

## Evergreen Config

Two "runtimes" are added to the config: one that builds with GCC and one that builds with Clang. The GCC build generates coredumps on assertion failures; the Clang build compiles with ASAN/UBSAN for runtime checks. Only the Ubuntu 18.04 distro is tested (notably does not test on Windows or macOS).

## Driver Installation

Only the minimum required CMake configuration variables are set:

- CMAKE_BUILD_TYPE: RelWithDebInfo.
- ENABLE_AUTOMATIC_INIT_AND_CLEANUP: OFF (ON is deprecated)
- ENABLE_SSL=OPENSSL" (required for authentication)

When using Clang (GCC on Ubuntu 18.04 does not appear to support `-fsanitize=address,undefined`), the `MONGO_SANITIZE=address,undefined` and `ENABLE_SASL=OFF` are also set. The latter is to avoid noisy LeakSanitizer warnings when exiting `main()` (this is worked around in the C Driver via the [bypass-dlclose.sh](https://github.com/mongodb/mongo-c-driver/blob/4b1c7751a1b00c3b79f044fe023075ec4a833903/.evergreen/scripts/bypass-dlclose.sh) script, but as I do not believe SASL is required for Atlas Testing, I opted for the simpler workaround of simply disabling SASL.

## Workload Executor

The workload executor invokes `test-atlas-executor` by passing the `connection-string` via `MONGOC_TEST_URI` and the `workload-spec` as the first command line argument.

If `test-atlas-executor` ever returns with a non-zero exit code (e.g. on an assertion failure leading to an `abort()`), a simple `events.json` and `results.json` is manually generated to properly communicate the error to Atlas Testing (per [Workload Executor Specification](https://mongodb-labs.github.io/drivers-atlas-testing/spec-workload-executor.html): "The workload executor’s exit code is not used for determining success/failure and is ignored."). In such cases, either ASAN/UBSAN or the call to `gdb` should generate and emit a stacktrace for inspection in logs.

Because `bson_as_json` does very little pretty-formatting of the generated JSON strings (everything is entirely on a single line), `jq` is used to prettify the JSON output for readability while simultaneously writing the files into the expected (original working) directory.