### PR TITLE
Run ignored test in Rust script

### DIFF
--- a/integrations/rust/workload-executor
+++ b/integrations/rust/workload-executor
@@ -25,6 +25,6 @@ export WORKLOAD_EXECUTOR_WORKING_DIRECTORY=$WORKING_DIRECTORY
 cd mongo-rust-driver
 
 # Write the test executable name to exe_name.txt
-cargo test get_exe_name --release
+cargo test get_exe_name --release -- --ignored
 
 RUST_BACKTRACE=1 $(cat exe_name.txt) workload_executor --nocapture -- --release


### PR DESCRIPTION
This is a minor update in the Rust workload executor to account for a change in a test in the driver.

succeeding patch: https://spruce.mongodb.com/version/646522b23e8e86cb9db2133b/tasks?sorts=STATUS%3AASC%3BBASE_STATUS%3ADESC