### PR TITLE
GODRIVER-2919 Fix the Go driver integration and update to Go 1.20

### DIFF
--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -741,10 +741,10 @@ axes:
         variables:
           ASYNC: "false"
           FRAMEWORK: "netcoreapp2.1"
-      - id: go-15
-        display_name: Go v1.15
+      - id: go-20
+        display_name: Go v1.20
         variables:
-          GOROOT: /opt/golang/go1.15
+          GOROOT: /opt/golang/go1.20
           GOPATH: /home/ubuntu/go
       - id: php-74
         display_name: PHP 7.4
@@ -839,7 +839,7 @@ buildvariants:
   matrix_spec:
     driver: ["go-master"]
     platform: ubuntu-18.04
-    runtime: go-15
+    runtime: go-20
   display_name: "${driver} ${platform} ${runtime}"
   tasks:
     - ".all"

--- a/integrations/go/go.mod
+++ b/integrations/go/go.mod
@@ -1,3 +1,19 @@
 module go-executor
 
-require go.mongodb.org/mongo-driver master
+go 1.20
+
+require go.mongodb.org/mongo-driver v1.13.0-prerelease.0.20230728173434-bf0e9bc29ed5
+
+require (
+	github.com/davecgh/go-spew v1.1.1 // indirect
+	github.com/golang/snappy v0.0.1 // indirect
+	github.com/klauspost/compress v1.13.6 // indirect
+	github.com/montanaflynn/stats v0.0.0-20171201202039-1bf9dbcd8cbe // indirect
+	github.com/xdg-go/pbkdf2 v1.0.0 // indirect
+	github.com/xdg-go/scram v1.1.2 // indirect
+	github.com/xdg-go/stringprep v1.0.4 // indirect
+	github.com/youmark/pkcs8 v0.0.0-20181117223130-1be2e3e5546d // indirect
+	golang.org/x/crypto v0.0.0-20220622213112-05595931fe9d // indirect
+	golang.org/x/sync v0.0.0-20220722155255-886fb9371eb4 // indirect
+	golang.org/x/text v0.7.0 // indirect
+)

--- a/integrations/go/install-driver.sh
+++ b/integrations/go/install-driver.sh
@@ -8,4 +8,5 @@ cd integrations/$DRIVER_DIRNAME
 export PATH=$GOROOT/bin:$PATH
 
 go get go.mongodb.org/mongo-driver@master
+go mod tidy
 go test -c workload_executor_test.go -o executor

--- a/integrations/go/workload_executor_test.go
+++ b/integrations/go/workload_executor_test.go
@@ -57,7 +57,7 @@ func TestAtlasPlannedMaintenance(t *testing.T) {
 	}()
 
 	// killAllSessions will return an auth error if it's run
-	fileReqs, testCases := unified.ParseTestFile(t, workloadSpec)
+	fileReqs, testCases := unified.ParseTestFile(t, workloadSpec, false)
 	// a workload must use a single test
 	if len(testCases) != 1 {
 		t.Fatalf("expected 1 test case, got %v", len(testCases))


### PR DESCRIPTION
[GODRIVER-2919](https://jira.mongodb.org/browse/GODRIVER-2919)

## Summary
* Fix the missing parameter in the `ParseTestFile` function call.
* Use valid `go.mod` and `go.sum` configs to make working on the Go Driver integration files easier (allows the Go language server to work properly). The Go driver integration "install" script still updates to the latest revision of the Go driver.
* Update Go version to 1.20