### PR TITLE
Avoid C Driver task failures due to ENABLE_EXTRA_ALIGNMENT

### DIFF
--- a/integrations/c/install-driver.sh
+++ b/integrations/c/install-driver.sh
@@ -33,6 +33,7 @@ declare -a cmake_config_vars=(
   "-DCMAKE_BUILD_TYPE=RelWithDebInfo"
   "-DCMAKE_INSTALL_PREFIX=${c_install_dir}"
   "-DENABLE_AUTOMATIC_INIT_AND_CLEANUP=OFF"
+  "-DENABLE_EXTRA_ALIGNMENT=OFF" # Interferes with ASAN.
 )
 
 # Unable to compile with ASAN/UBSAN using GCC on ubuntu1804-drivers-atlas-testing.


### PR DESCRIPTION
Addresses ongoing task failures due to conflict with ASAN when building with Clang. Verified by [this patch](https://spruce.mongodb.com/version/64c950553627e05542834120).