### PR TITLE
GODRIVER-2946 Remove call to mtest.T.Close in Go integration.

### DIFF
--- a/integrations/go/workload_executor_test.go
+++ b/integrations/go/workload_executor_test.go
@@ -67,7 +67,6 @@ func TestAtlasPlannedMaintenance(t *testing.T) {
 		RunOn(fileReqs...).
 		CreateClient(false)
 	mt := mtest.New(t, mtOpts)
-	defer mt.Close()
 
 	testCase := testCases[0]
 	testOpts := mtest.NewOptions().


### PR DESCRIPTION
The Go driver recently removed the `mtest.T.Close` function, which is now called automatically (see https://github.com/mongodb/mongo-go-driver/pull/1347). Stop calling it in the Go integration.