### PR TITLE
test(DRIVERS-2700): remove failure also from evg run

### DIFF
--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -396,22 +396,6 @@ tasks:
 
   # Atlas test tasks
   # ================
-  - name: atlas-failure-read
-    tags: ["all"]
-    commands:
-      - func: "run atlas test"
-        vars:
-          WORKLOAD_FILE: workloads/reads.yml
-          TEST_FILE: tests/atlas/failure.yml
-          ATLAS: "true"
-  - name: atlas-failure-write
-    tags: ["all"]
-    commands:
-      - func: "run atlas test"
-        vars:
-          WORKLOAD_FILE: workloads/writes.yml
-          TEST_FILE: tests/atlas/failure.yml
-          ATLAS: "true"
   - name: atlas-retryReads-move-sharded
     tags: ["all"]
     commands:


### PR DESCRIPTION
failure.yml was removed but still expected in the evergreen config.