### PR TITLE
fix(NODE-5602): fix node npm install

### DIFF
--- a/integrations/node/install-driver.sh
+++ b/integrations/node/install-driver.sh
@@ -5,6 +5,7 @@ set -o errexit  # Exit the script with error if any of the commands fail
 
 export PROJECT_DIRECTORY="$(pwd)/node-mongodb-native"
 export NODE_LTS_VERSION="$NODE_LTS_VERSION"
+export NPM_VERSION=9
 
 cd ${PROJECT_DIRECTORY}
 . .evergreen/install-dependencies.sh


### PR DESCRIPTION
Fixes npm failures by pinning npm to version 9 which still supports Node 16