### PR TITLE
DRIVERS-2715 Investigate Increased Costs of Drivers Atlas QA Usage

### DIFF
--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -154,7 +154,7 @@ functions:
         # Next commands will exit with appropriate status
         continue_on_err: true
         env:
-          ATLAS_PROJECT_NAME: ${project}
+          ATLAS_PROJECT_NAME: "${project}-${execution}"
           CLUSTER_NAME_SALT: ${build_id}
           ATLAS_API_USERNAME: ${atlas_key}
           ATLAS_API_PASSWORD: ${atlas_secret}
@@ -190,7 +190,7 @@ functions:
       params:
         working_dir: astrolabe-src
         env:
-          ATLAS_PROJECT_NAME: ${project}
+          ATLAS_PROJECT_NAME: "${project}-${execution}"
           CLUSTER_NAME_SALT: ${build_id}
           ATLAS_API_USERNAME: ${atlas_key}
           ATLAS_API_PASSWORD: ${atlas_secret}
@@ -218,7 +218,7 @@ functions:
       params:
         working_dir: astrolabe-src
         env:
-          ATLAS_PROJECT_NAME: ${project}
+          ATLAS_PROJECT_NAME: "${project}-${execution}"
           CLUSTER_NAME_SALT: ${build_id}
           ATLAS_API_USERNAME: ${atlas_key}
           ATLAS_API_PASSWORD: ${atlas_secret}

--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -228,6 +228,7 @@ functions:
           ATLAS_ADMIN_API_PASSWORD: ${atlas_admin_api_password}
         add_expansions_to_env: true
         script: |
+          set -eux
           # Only run after Atlas tasks.
           if [ "${ATLAS}" != "true" ]; then
             echo "Skipping Atlas cluster cleanup because it's not a Atlas task."
@@ -776,7 +777,7 @@ buildvariants:
   tasks:
     # Kind tasks can't run on Windows, so exclude them.
     - ".all !.kind"
-# TODO(BUILD-17806): GLIBC on Ubuntu 18 is too low (2.27) for Node 18 and Node 20 (2.28) 
+# TODO(BUILD-17806): GLIBC on Ubuntu 18 is too low (2.27) for Node 18 and Node 20 (2.28)
 - matrix_name: tests-node
   matrix_spec:
     driver:

--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -154,7 +154,7 @@ functions:
         # Next commands will exit with appropriate status
         continue_on_err: true
         env:
-          ATLAS_PROJECT_NAME: "${project}-${execution}"
+          ATLAS_PROJECT_NAME: "${project}-${task_id}-${execution}"
           CLUSTER_NAME_SALT: ${build_id}
           ATLAS_API_USERNAME: ${atlas_key}
           ATLAS_API_PASSWORD: ${atlas_secret}
@@ -190,7 +190,7 @@ functions:
       params:
         working_dir: astrolabe-src
         env:
-          ATLAS_PROJECT_NAME: "${project}-${execution}"
+          ATLAS_PROJECT_NAME: "${project}-${task_id}-${execution}"
           CLUSTER_NAME_SALT: ${build_id}
           ATLAS_API_USERNAME: ${atlas_key}
           ATLAS_API_PASSWORD: ${atlas_secret}
@@ -218,7 +218,7 @@ functions:
       params:
         working_dir: astrolabe-src
         env:
-          ATLAS_PROJECT_NAME: "${project}-${execution}"
+          ATLAS_PROJECT_NAME: "${project}-${task_id}-${execution}"
           CLUSTER_NAME_SALT: ${build_id}
           ATLAS_API_USERNAME: ${atlas_key}
           ATLAS_API_PASSWORD: ${atlas_secret}

--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -65,6 +65,27 @@ functions:
         working_dir: astrolabe-src
         command: |
           astrolabevenv/${PYTHON_BIN_DIR}/pip install -e .
+    # Handle the project id
+    - command: shell.exec
+      type: setup
+      params:
+        working_dir: astrolabe-src
+        add_expansions_to_env: true
+      script: |
+        # create a unique atlas project per task and execution.
+        # task_id has the structure $projectID_$variantName_$taskName_$commitHash_$createTime, which is unique per task per ci run per project.
+        # task_id is NOT unique across restarts of the same task though, so we include execution to ensure that it is unique for every restart too.
+        #
+        # the generated string is then transformed to satisfy Atlas cluster naming requirements
+        # - the string cannot be > 64 characters long, so we hash the name to shorten it and maintain its uniqueness (hashes do have collisions but infrequently
+        #   enough that hashing suffices here)
+        # - we convert it to hex encoding because cluster names must be alphanumeric (hyphens are allowed)
+        transform="process.stdout.write(require('crypto').createHash('md5').update(process.argv[1]).digest().toString('hex'))"
+        unique_id=$(node -e $transform "${task_id}-${execution}")
+        echo "ATLAS_PROJECT_NAME:$project-$unique_id" > atlas_project_name.yml
+    - command: expansions.update
+      params:
+        file: atlas_project_name.yml
 
   "install driver":
     # Clone driver source code into the 'astrolabe-src/<driver-repo-name>' directory.
@@ -154,7 +175,7 @@ functions:
         # Next commands will exit with appropriate status
         continue_on_err: true
         env:
-          ATLAS_PROJECT_NAME: "${project}-${task_id}-${execution}"
+          ATLAS_PROJECT_NAME: ${ATLAS_PROJECT_NAME}
           CLUSTER_NAME_SALT: ${build_id}
           ATLAS_API_USERNAME: ${atlas_key}
           ATLAS_API_PASSWORD: ${atlas_secret}
@@ -190,7 +211,7 @@ functions:
       params:
         working_dir: astrolabe-src
         env:
-          ATLAS_PROJECT_NAME: "${project}-${task_id}-${execution}"
+          ATLAS_PROJECT_NAME: ${ATLAS_PROJECT_NAME}
           CLUSTER_NAME_SALT: ${build_id}
           ATLAS_API_USERNAME: ${atlas_key}
           ATLAS_API_PASSWORD: ${atlas_secret}
@@ -218,7 +239,7 @@ functions:
       params:
         working_dir: astrolabe-src
         env:
-          ATLAS_PROJECT_NAME: "${project}-${task_id}-${execution}"
+          ATLAS_PROJECT_NAME: ${ATLAS_PROJECT_NAME}
           CLUSTER_NAME_SALT: ${build_id}
           ATLAS_API_USERNAME: ${atlas_key}
           ATLAS_API_PASSWORD: ${atlas_secret}

--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -71,18 +71,18 @@ functions:
       params:
         working_dir: astrolabe-src
         add_expansions_to_env: true
-      script: |
-        # create a unique atlas project per task and execution.
-        # task_id has the structure $projectID_$variantName_$taskName_$commitHash_$createTime, which is unique per task per ci run per project.
-        # task_id is NOT unique across restarts of the same task though, so we include execution to ensure that it is unique for every restart too.
-        #
-        # the generated string is then transformed to satisfy Atlas cluster naming requirements
-        # - the string cannot be > 64 characters long, so we hash the name to shorten it and maintain its uniqueness (hashes do have collisions but infrequently
-        #   enough that hashing suffices here)
-        # - we convert it to hex encoding because cluster names must be alphanumeric (hyphens are allowed)
-        transform="process.stdout.write(require('crypto').createHash('md5').update(process.argv[1]).digest().toString('hex'))"
-        unique_id=$(node -e $transform "${task_id}-${execution}")
-        echo "ATLAS_PROJECT_NAME:$project-$unique_id" > atlas_project_name.yml
+        script: |
+          # create a unique atlas project per task and execution.
+          # task_id has the structure $projectID_$variantName_$taskName_$commitHash_$createTime, which is unique per task per ci run per project.
+          # task_id is NOT unique across restarts of the same task though, so we include execution to ensure that it is unique for every restart too.
+          #
+          # the generated string is then transformed to satisfy Atlas cluster naming requirements
+          # - the string cannot be > 64 characters long, so we hash the name to shorten it and maintain its uniqueness (hashes do have collisions but infrequently
+          #   enough that hashing suffices here)
+          # - we convert it to hex encoding because cluster names must be alphanumeric (hyphens are allowed)
+          transform="process.stdout.write(require('crypto').createHash('md5').update(process.argv[1]).digest().toString('hex'))"
+          unique_id=$(node -e $transform "${task_id}-${execution}")
+          echo "ATLAS_PROJECT_NAME:$project-$unique_id" > atlas_project_name.yml
     - command: expansions.update
       params:
         file: atlas_project_name.yml

--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -65,7 +65,7 @@ functions:
         working_dir: astrolabe-src
         command: |
           astrolabevenv/${PYTHON_BIN_DIR}/pip install -e .
-    # Handle the project id
+    # Handle the project name.
     - command: shell.exec
       type: setup
       params:
@@ -85,7 +85,7 @@ functions:
           echo "ATLAS_PROJECT_NAME:$project-$unique_id" > atlas_project_name.yml
     - command: expansions.update
       params:
-        file: atlas_project_name.yml
+        file: astrolabe-src/atlas_project_name.yml
 
   "install driver":
     # Clone driver source code into the 'astrolabe-src/<driver-repo-name>' directory.

--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -82,10 +82,12 @@ functions:
           # - we convert it to hex encoding because cluster names must be alphanumeric (hyphens are allowed)
           transform="process.stdout.write(require('crypto').createHash('md5').update(process.argv[1]).digest().toString('hex'))"
           unique_id=$(node -e $transform "${task_id}-${execution}")
-          echo "ATLAS_PROJECT_NAME:$project-$unique_id" > atlas_project_name.yml
+          cat <<EOT > expansion.yml
+          ATLAS_PROJECT_NAME: "$project-$unique_id"
+          EOT
     - command: expansions.update
       params:
-        file: astrolabe-src/atlas_project_name.yml
+        file: astrolabe-src/expansion.yml
 
   "install driver":
     # Clone driver source code into the 'astrolabe-src/<driver-repo-name>' directory.

--- a/astrolabe/atlas_runner.py
+++ b/astrolabe/atlas_runner.py
@@ -74,9 +74,7 @@ class AtlasTestCase:
 
         # Generate a unique project name with timestamp & random suffix
         current_timestamp = int(_time.time())
-        timestamp_suffix = '-' + str(current_timestamp)            
-        random_suffix = '-' + str(int(random.random() * 1_000_000_000))
-        self.project_name = self.config.project_name + timestamp_suffix + random_suffix
+        self.project_name = self.config.project_name
         self.project = None
 
     @property
@@ -116,7 +114,7 @@ class AtlasTestCase:
         Initialize a cluster with the configuration required by the test
         specification.
         """
-        
+
         if no_create:
             try:
                 # If --no-create was specified and the cluster exists, skip
@@ -130,7 +128,7 @@ class AtlasTestCase:
                     LOGGER.warn('Cluster was not found, will create one')
             except AssertionError as exc:
                 LOGGER.warn('Configuration did not match: %s. Recreating the cluster' % exc)
-            
+
         LOGGER.info("Initializing cluster {!r}".format(self.cluster_name))
 
         cluster_config = self.spec.initialConfiguration.\
@@ -158,7 +156,7 @@ class AtlasTestCase:
     def run(self, persist_cluster=False, startup_time=1):
         LOGGER.info("Running test {!r} on cluster {!r}".format(
             self.id, self.cluster_name))
-        
+
         # Step-1: sanity-check the cluster configuration.
         self.verify_cluster_configuration_matches(self.spec.initialConfiguration)
 
@@ -177,9 +175,9 @@ class AtlasTestCase:
             for operation in self.spec.operations:
                 if len(operation) != 1:
                     raise ValueError("Operation must have exactly one key: %s" % operation)
-                    
+
                 op_name, op_spec = list(operation.items())[0]
-                
+
                 if op_name == 'setClusterConfiguration':
                     # Step-3: begin maintenance routine.
                     final_config = op_spec
@@ -201,7 +199,7 @@ class AtlasTestCase:
                     self.wait_for_idle()
                     self.verify_cluster_configuration_matches(final_config)
                     LOGGER.info("Cluster maintenance complete")
-                    
+
                 elif op_name == 'testFailover':
                     timer = Timer()
                     timer.start()
@@ -235,48 +233,48 @@ class AtlasTestCase:
 
                     self.wait_for_planning(start_time)
                     self.wait_for_idle()
-                    
+
                 elif op_name == 'sleep':
                     _time.sleep(op_spec)
-                    
+
                 elif op_name == 'waitForIdle':
                     self.wait_for_idle()
-                    
+
                 elif op_name == 'restartVms':
                     rv = self.admin_client.nds.groups[self.project.id].clusters[self.cluster_name].reboot.post(api_version='private')
-                    
+
                     self.wait_for_idle()
-                    
+
                 elif op_name == 'assertPrimaryRegion':
                     region = op_spec['region']
-                    
+
                     cluster_config = self.cluster_url.get().data
                     timer = Timer()
                     timer.start()
                     timeout = op_spec.get('timeout', 90)
-                    
+
                     with mongo_client(self.get_connection_string()) as mc:
                         while True:
                             rsc = mc.admin.command('replSetGetConfig')
                             member = [m for m in rsc['config']['members']
                                 if m['horizons']['PUBLIC'] == '%s:%s' % mc.primary][0]
                             member_region = member['tags']['region']
-                        
+
                             if region == member_region:
                                 break
-                                
+
                             if timer.elapsed > timeout:
                                 raise Exception("Primary in cluster not in expected region '%s' (actual region '%s')" % (region, member_region))
                             else:
                                 sleep(5)
-                    
+
                 else:
                     raise Exception('Unrecognized operation %s' % op_name)
 
             # Wait 10 seconds to ensure that the driver is not experiencing any
             # errors after the maintenance has concluded.
             sleep(10)
-            
+
             # Step-5: interrupt driver workload and capture streams
             stats = self.workload_runner.stop()
 
@@ -308,7 +306,7 @@ class AtlasTestCase:
                 LOGGER.info("SUCCEEDED: {!r}".format(self.id))
                 # Directly log output of successful tests as xunit output
                 # is only visible for failed tests.
-            
+
             # Step 7: download logs asynchronously and delete cluster.
             # TODO: https://github.com/mongodb-labs/drivers-atlas-testing/issues/4
             if not persist_cluster:
@@ -319,7 +317,7 @@ class AtlasTestCase:
             return junit_test
         finally:
             self.workload_runner.terminate()
-        
+
     def wait_for_idle(self):
         # Small delay to account for Atlas not updating cluster state
         # synchronously potentially in all maintenance operations
@@ -350,7 +348,7 @@ class AtlasTestCase:
             if actual_state == wanted_state:
                 ok = True
                 break
-            
+
             msg = "Cluster %s: current state: %s; wanted state: %s; waited for %.1f sec" % (self.cluster_name, actual_state, wanted_state, timer.elapsed)
             now = monotonic()
             # Notify once a minute, see DRIVERS-2013.
@@ -361,7 +359,7 @@ class AtlasTestCase:
                 LOGGER.debug(msg)
         if not ok:
             raise PollingTimeoutError("Polling timed out after %s seconds" % timeout)
-            
+
     def wait_for_planning(self, start_time):
         timer = Timer()
         timer.start()
@@ -375,7 +373,7 @@ class AtlasTestCase:
             if planning_time > start_time:
                 ok = True
                 break
-            
+
             msg = "Cluster %s: last planned: %s; wanted after: %s; waited for %.1f sec" % (self.cluster_name, planning_time, start_time, timer.elapsed)
             now = monotonic()
             # Notify once a minute, see DRIVERS-2013.
@@ -384,9 +382,9 @@ class AtlasTestCase:
                 LOGGER.info(msg)
             else:
                 LOGGER.debug(msg)
-            
+
             _time.sleep(5)
-        
+
         if not ok:
             raise PollingTimeoutError("Timed out waiting for planning after %s seconds" % timeout)
 
@@ -428,7 +426,7 @@ class SpecTestRunnerBase:
 
         # Step-2: clean old projects with same name base from organization.
         if not no_create:
-            self.clean_old_projects(org.id)                             
+            self.clean_old_projects(org.id)
 
         with open(workload_file) as f:
             workload = JSONObject.from_dict(yaml.safe_load(f))
@@ -453,7 +451,7 @@ class SpecTestRunnerBase:
                 workload=workload,
                 configuration=self.config)
             self.cases.append(atlas_test_case)
-        
+
             # Set up Atlas for tests.
             # Step-1: check that the project exists or else create it.
             pro_name = atlas_test_case.project_name
@@ -499,7 +497,7 @@ class SpecTestRunnerBase:
                     int(project_timestamp) < current_timestamp - self.project_expiration_threshold_seconds:
                     try:
                         delete_project(client=self.client, project_id=project.id)
-                        LOGGER.info("Successfully deleted project {!r}, id: {!r}".format(project.name, project.id)) 
+                        LOGGER.info("Successfully deleted project {!r}, id: {!r}".format(project.name, project.id))
                     except AtlasApiError as esc:
                         # the project may have been deleted by another test just now.
                         if esc.error_code == 'GROUP_NOT_FOUND':

--- a/astrolabe/atlas_runner.py
+++ b/astrolabe/atlas_runner.py
@@ -72,8 +72,6 @@ class AtlasTestCase:
         # Initialize wrapper class for running workload executor.
         self.workload_runner = DriverWorkloadSubprocessRunner()
 
-        # Generate a unique project name with timestamp & random suffix
-        current_timestamp = int(_time.time())
         self.project_name = self.config.project_name
         self.project = None
 

--- a/astrolabe/cli.py
+++ b/astrolabe/cli.py
@@ -143,7 +143,7 @@ def cli(ctx, atlas_base_url, atlas_api_username,
             timeout=http_timeout)
     else:
         admin_client = None
-    
+
     ctx.obj = ContextStore(client, admin_client)
 
     # Configure logging.
@@ -558,7 +558,7 @@ def get_logs_cmd(ctx, spec_test_file, workload_file, org_id, project_name,
     Retrieves logs for the cluster and saves them in logs.tar.gz in the
     current working directory.
     """
-    
+
     if only_on_failure:
         if os.path.exists('status'):
             with open('status') as fp:
@@ -574,7 +574,7 @@ def get_logs_cmd(ctx, spec_test_file, workload_file, org_id, project_name,
     cluster_name = get_cluster_name(
         get_test_name(spec_test_file, workload_file),
         cluster_name_salt)
-    
+
     organization = cmd.get_organization_by_id(
         client=ctx.obj.client,
         org_id=org_id)
@@ -615,6 +615,10 @@ def delete_test_cluster(ctx, spec_test_file, workload_file, org_id, project_name
             ctx.obj.client.groups[project.id].clusters[cluster_name].delete()
         except AtlasApiBaseError:
             pass
+    else:
+        print('project not found!')
+        import sys
+        sys.exit(1)
 
 
 @atlas_tests.command('run')

--- a/astrolabe/cli.py
+++ b/astrolabe/cli.py
@@ -601,7 +601,7 @@ def delete_test_cluster(ctx, spec_test_file, workload_file, org_id, project_name
     This command does not error if a cluster bearing the expected name is not found.
     """
     # Step-1: determine the cluster name for the given test.
-    print("\n\n\nHELLO THERE"
+    print("\n\n\nHELLO THERE")
     print(f"{=spec_test_file}, {=workload_file}, {=cluster_name_salt}")
     cluster_name = get_cluster_name(
         get_test_name(spec_test_file, workload_file),

--- a/astrolabe/cli.py
+++ b/astrolabe/cli.py
@@ -602,17 +602,17 @@ def delete_test_cluster(ctx, spec_test_file, workload_file, org_id, project_name
     """
     # Step-1: determine the cluster name for the given test.
     print("\n\n\nHELLO THERE")
-    print(f"{=spec_test_file}, {=workload_file}, {=cluster_name_salt}")
+    print(f"{spec_test_file=}, {workload_file=}, {cluster_name_salt=}")
     cluster_name = get_cluster_name(
         get_test_name(spec_test_file, workload_file),
         cluster_name_salt)
-    print(f"{=cluster_name}")
+    print(f"{cluster_name=}")
     # Step-2: delete the cluster.
     organization = cmd.get_organization_by_id(
         client=ctx.obj.client, org_id=org_id)
     project = cmd.get_project(
         client=ctx.obj.client, project_name=project_name, organization_id=organization.id)
-    print(f"{=project}")
+    print(f"{project=}")
     if project:
         print("trying to delete")
         try:

--- a/astrolabe/cli.py
+++ b/astrolabe/cli.py
@@ -616,6 +616,9 @@ def delete_test_cluster(ctx, spec_test_file, workload_file, org_id, project_name
     if project:
         print("trying to delete")
         try:
+            print(ctx.obj.client.groups[project.id].clusters)
+            print(dir(ctx.obj.client.groups[project.id].clusters))
+            print(dir(ctx.obj.client.groups[project.id]))
             ctx.obj.client.groups[project.id].clusters[cluster_name].delete()
             print("deleted!")
         except AtlasApiBaseError as e:

--- a/astrolabe/cli.py
+++ b/astrolabe/cli.py
@@ -606,7 +606,7 @@ def delete_test_cluster(ctx, spec_test_file, workload_file, org_id, project_name
     cluster_name = get_cluster_name(
         get_test_name(spec_test_file, workload_file),
         cluster_name_salt)
-    print(f"{cluster_name=}")
+    print(f"{cluster_name=}, {project_name=}")
     # Step-2: delete the cluster.
     organization = cmd.get_organization_by_id(
         client=ctx.obj.client, org_id=org_id)
@@ -623,6 +623,7 @@ def delete_test_cluster(ctx, spec_test_file, workload_file, org_id, project_name
             print("deleted!")
         except AtlasApiBaseError as e:
             print("failed", e)
+            import sys
             sys.exit(1)
     else:
         print('project not found!')

--- a/astrolabe/cli.py
+++ b/astrolabe/cli.py
@@ -601,20 +601,26 @@ def delete_test_cluster(ctx, spec_test_file, workload_file, org_id, project_name
     This command does not error if a cluster bearing the expected name is not found.
     """
     # Step-1: determine the cluster name for the given test.
+    print("\n\n\nHELLO THERE"
+    print(f"{=spec_test_file}, {=workload_file}, {=cluster_name_salt}")
     cluster_name = get_cluster_name(
         get_test_name(spec_test_file, workload_file),
         cluster_name_salt)
-
+    print(f"{=cluster_name}")
     # Step-2: delete the cluster.
     organization = cmd.get_organization_by_id(
         client=ctx.obj.client, org_id=org_id)
     project = cmd.get_project(
         client=ctx.obj.client, project_name=project_name, organization_id=organization.id)
+    print(f"{=project}")
     if project:
+        print("trying to delete")
         try:
             ctx.obj.client.groups[project.id].clusters[cluster_name].delete()
-        except AtlasApiBaseError:
-            pass
+            print("deleted!")
+        except AtlasApiBaseError as e:
+            print("failed", e)
+            sys.exit(1)
     else:
         print('project not found!')
         import sys

--- a/astrolabe/cli.py
+++ b/astrolabe/cli.py
@@ -601,34 +601,25 @@ def delete_test_cluster(ctx, spec_test_file, workload_file, org_id, project_name
     This command does not error if a cluster bearing the expected name is not found.
     """
     # Step-1: determine the cluster name for the given test.
-    print("\n\n\nHELLO THERE")
-    print(f"{spec_test_file=}, {workload_file=}, {cluster_name_salt=}")
     cluster_name = get_cluster_name(
         get_test_name(spec_test_file, workload_file),
         cluster_name_salt)
-    print(f"{cluster_name=}, {project_name=}")
+    msg = f"Deleting cluster {cluster_name} in project {project_name}..."
+    print(msg)
+
     # Step-2: delete the cluster.
     organization = cmd.get_organization_by_id(
         client=ctx.obj.client, org_id=org_id)
     project = cmd.get_project(
         client=ctx.obj.client, project_name=project_name, organization_id=organization.id)
-    print(f"{project=}")
     if project:
-        print("trying to delete")
         try:
-            print(ctx.obj.client.groups[project.id].clusters)
-            print(dir(ctx.obj.client.groups[project.id].clusters))
-            print(dir(ctx.obj.client.groups[project.id]))
             ctx.obj.client.groups[project.id].clusters[cluster_name].delete()
-            print("deleted!")
+            print(f"{msg} done.")
         except AtlasApiBaseError as e:
-            print("failed", e)
-            import sys
-            sys.exit(1)
+            pprint(e)
     else:
-        print('project not found!')
-        import sys
-        sys.exit(1)
+        print(f"Project {project_name} not found!")
 
 
 @atlas_tests.command('run')


### PR DESCRIPTION
The clusters were silently failing to delete because they were trying to delete the cluster in `drivers-atlas-testing` instead of the the newly created project.