### PR TITLE
DRIVERS-2734 Ensure projects are deleted along with the cluster

### DIFF
--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -188,14 +188,13 @@ functions:
         add_expansions_to_env: true
         script: |
           astrolabevenv/${PYTHON_BIN_DIR}/astrolabe projects \
-            delete-all ${TEST_FILE} \
-            --workload-file ${WORKLOAD_FILE}
+            delete-all ${atlas_organization_id}
 
-          astrolabevenv/${PYTHON_BIN_DIR}/astrolabe atlas-tests \
-            run-one ${TEST_FILE} \
-            --workload-file ${WORKLOAD_FILE} \
-            --workload-executor integrations/${DRIVER_DIRNAME}/workload-executor \
-            --no-delete
+          # astrolabevenv/${PYTHON_BIN_DIR}/astrolabe atlas-tests \
+          #   run-one ${TEST_FILE} \
+          #   --workload-file ${WORKLOAD_FILE} \
+          #   --workload-executor integrations/${DRIVER_DIRNAME}/workload-executor \
+          #   --no-delete
     - command: subprocess.exec
       type: setup
       params:

--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -188,6 +188,10 @@ functions:
         add_expansions_to_env: true
         script: |
           astrolabevenv/${PYTHON_BIN_DIR}/astrolabe atlas-tests \
+            delete-all ${TEST_FILE} \
+            --workload-file ${WORKLOAD_FILE}
+
+          astrolabevenv/${PYTHON_BIN_DIR}/astrolabe atlas-tests \
             run-one ${TEST_FILE} \
             --workload-file ${WORKLOAD_FILE} \
             --workload-executor integrations/${DRIVER_DIRNAME}/workload-executor \

--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -259,7 +259,7 @@ functions:
           fi
 
           astrolabevenv/${PYTHON_BIN_DIR}/astrolabe atlas-tests \
-            delete-project ${TEST_FILE} \
+            delete-cluster ${TEST_FILE} \
             --workload-file ${WORKLOAD_FILE}
 
   "create kind cluster":

--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -187,14 +187,11 @@ functions:
           ATLAS_ADMIN_API_PASSWORD: ${atlas_admin_api_password}
         add_expansions_to_env: true
         script: |
-          astrolabevenv/${PYTHON_BIN_DIR}/astrolabe projects \
-            delete-all --org-id=${atlas_organization_id}
-
-          # astrolabevenv/${PYTHON_BIN_DIR}/astrolabe atlas-tests \
-          #   run-one ${TEST_FILE} \
-          #   --workload-file ${WORKLOAD_FILE} \
-          #   --workload-executor integrations/${DRIVER_DIRNAME}/workload-executor \
-          #   --no-delete
+          astrolabevenv/${PYTHON_BIN_DIR}/astrolabe atlas-tests \
+            run-one ${TEST_FILE} \
+            --workload-file ${WORKLOAD_FILE} \
+            --workload-executor integrations/${DRIVER_DIRNAME}/workload-executor \
+            --no-delete
     - command: subprocess.exec
       type: setup
       params:

--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -188,7 +188,7 @@ functions:
         add_expansions_to_env: true
         script: |
           astrolabevenv/${PYTHON_BIN_DIR}/astrolabe projects \
-            delete-all ${atlas_organization_id}
+            delete-all --org-id=${atlas_organization_id}
 
           # astrolabevenv/${PYTHON_BIN_DIR}/astrolabe atlas-tests \
           #   run-one ${TEST_FILE} \

--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -187,7 +187,7 @@ functions:
           ATLAS_ADMIN_API_PASSWORD: ${atlas_admin_api_password}
         add_expansions_to_env: true
         script: |
-          astrolabevenv/${PYTHON_BIN_DIR}/astrolabe atlas-tests \
+          astrolabevenv/${PYTHON_BIN_DIR}/astrolabe projects \
             delete-all ${TEST_FILE} \
             --workload-file ${WORKLOAD_FILE}
 

--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -259,7 +259,7 @@ functions:
           fi
 
           astrolabevenv/${PYTHON_BIN_DIR}/astrolabe atlas-tests \
-            delete-cluster ${TEST_FILE} \
+            delete-project ${TEST_FILE} \
             --workload-file ${WORKLOAD_FILE}
 
   "create kind cluster":

--- a/astrolabe/cli.py
+++ b/astrolabe/cli.py
@@ -621,6 +621,15 @@ def delete_test_cluster(ctx, spec_test_file, workload_file, org_id, project_name
     else:
         print(f"Project {project_name} not found!")
 
+    # Step-3: delete the project.
+    msg = f"Deleting project {project_name}..."
+    if project:
+        try:
+            ctx.obj.client.groups[project.id].delete()
+            print(f"{msg} done.")
+        except AtlasApiBaseError as e:
+            pprint(e)
+
 
 @atlas_tests.command('run')
 @click.argument("spec_tests_directory", type=click.Path(

--- a/astrolabe/cli.py
+++ b/astrolabe/cli.py
@@ -14,6 +14,7 @@
 
 import logging
 import os
+import time
 import unittest
 from pprint import pprint
 from urllib.parse import unquote_plus
@@ -628,11 +629,18 @@ def delete_test_cluster(ctx, spec_test_file, workload_file, org_id, project_name
     msg = f"Deleting project {project_name}..."
     if project:
         print(msg)
-        try:
-            client.groups[project.id].delete().data
-            print(f"{msg} done.")
-        except AtlasApiBaseError as e:
-            pprint(e.detail)
+        while 1:
+            try:
+                client.groups[project.id].delete().data
+                print(f"{msg} done.")
+                break
+            except AtlasApiBaseError as e:
+                if e.error_code == 409:
+                    print(e.datail)
+                    time.sleep(10)
+                else:
+                    pprint(e.detail)
+                    break
 
 
 @atlas_tests.command('run')

--- a/astrolabe/cli.py
+++ b/astrolabe/cli.py
@@ -635,6 +635,9 @@ def delete_test_cluster(ctx, spec_test_file, workload_file, org_id, project_name
                 print(f"{msg} done.")
                 break
             except AtlasApiBaseError as e:
+                # The API returns error code 409 when the project cannot be
+                # deleted because there is a cluster still running, we
+                # sleep to allow the cluster to shut down.
                 if e.error_code == 409:
                     print(e.datail)
                     time.sleep(10)

--- a/astrolabe/cli.py
+++ b/astrolabe/cli.py
@@ -610,13 +610,14 @@ def delete_test_cluster(ctx, spec_test_file, workload_file, org_id, project_name
     print(msg)
 
     # Step-2: delete the cluster.
+    client =ctx.obj.client
     organization = cmd.get_organization_by_id(
-        client=ctx.obj.client, org_id=org_id)
+        client=client, org_id=org_id)
     project = cmd.get_project(
-        client=ctx.obj.client, project_name=project_name, organization_id=organization.id)
+        client=client, project_name=project_name, organization_id=organization.id)
     if project:
         try:
-            ctx.obj.client.groups[project.id].clusters[cluster_name].delete()
+            client.groups[project.id].clusters[cluster_name].delete().data
             print(f"{msg} done.")
         except AtlasApiBaseError as e:
             pprint(e)
@@ -626,8 +627,9 @@ def delete_test_cluster(ctx, spec_test_file, workload_file, org_id, project_name
     # Step-3: delete the project.
     msg = f"Deleting project {project_name}..."
     if project:
+        print(msg)
         try:
-            ctx.obj.client.groups[project.id].delete()
+            client.groups[project.id].delete().data
             print(f"{msg} done.")
         except AtlasApiBaseError as e:
             pprint(e)

--- a/astrolabe/cli.py
+++ b/astrolabe/cli.py
@@ -225,9 +225,11 @@ def delete_all_projects(ctx, org_id):
     """Delete all Atlas Projects in organization."""
     projects_res = cmd.list_projects_in_org(client=ctx.obj.client, org_id=org_id)
     for project in projects_res['results']:
-        cmd.delete_project(client=ctx.obj.client, project_id=project.id)
-        LOGGER.info("Successfully deleted project {!r}, id: {!r}".format(project.name, project.id))
-
+        try:
+            cmd.delete_project(client=ctx.obj.client, project_id=project.id)
+            LOGGER.info("Successfully deleted project {!r}, id: {!r}".format(project.name, project.id))
+        except Exception as e:
+            LOGGER.exception(e)
 
 @atlas_projects.command('get-one')
 @ATLASPROJECTNAME_OPTION

--- a/astrolabe/cli.py
+++ b/astrolabe/cli.py
@@ -632,7 +632,7 @@ def delete_test_cluster(ctx, spec_test_file, workload_file, org_id, project_name
             client.groups[project.id].delete().data
             print(f"{msg} done.")
         except AtlasApiBaseError as e:
-            pprint(e)
+            pprint(e.detail)
 
 
 @atlas_tests.command('run')

--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,7 @@ else:
 install_requires = [
     'click>=7,<8', 'requests>=2,<3',
     'pymongo>=3.10,<4', 'dnspython>=1.16,<2',
-    'pyyaml>=5,<6', 'tabulate>=0.8,<0.9',
+    'pyyaml>=5,<7', 'tabulate>=0.8,<0.9',
     'numpy<2',
     'junitparser>=1,<2']
 if sys.platform == 'win32':


### PR DESCRIPTION
Verified with https://spruce.mongodb.com/task/drivers_atlas_testing_tests_python__driver~pymongo_master_platform~ubuntu_18.04_runtime~python39_atlas_retryReads_move_patch_fca5526934ffbc67d485b8ec0960e843b85db9d8_6511dfcac9ec44bf4d8f36f9_23_09_25_19_30_27/logs?execution=0 that no projects remained open.