### PR TITLE
DRIVERS-2645 Use clean_old_projects to delete projects

### DIFF
--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -65,6 +65,29 @@ functions:
         working_dir: astrolabe-src
         command: |
           astrolabevenv/${PYTHON_BIN_DIR}/pip install -e .
+    # Handle the project name.
+    - command: shell.exec
+      type: setup
+      params:
+        working_dir: astrolabe-src
+        add_expansions_to_env: true
+        script: |
+          # create a unique atlas project per task and execution.
+          # task_id has the structure $projectID_$variantName_$taskName_$commitHash_$createTime, which is unique per task per ci run per project.
+          # task_id is NOT unique across restarts of the same task though, so we include execution to ensure that it is unique for every restart too.
+          #
+          # the generated string is then transformed to satisfy Atlas cluster naming requirements
+          # - the string cannot be > 64 characters long, so we hash the name to shorten it and maintain its uniqueness (hashes do have collisions but infrequently
+          #   enough that hashing suffices here)
+          # - we convert it to hex encoding because cluster names must be alphanumeric (hyphens are allowed)
+          transform="process.stdout.write(require('crypto').createHash('md5').update(process.argv[1]).digest().toString('hex'))"
+          unique_id=$(node -e $transform "${task_id}-${execution}")
+          cat <<EOT > expansion.yml
+          ATLAS_PROJECT_NAME: "$project-$unique_id"
+          EOT
+    - command: expansions.update
+      params:
+        file: astrolabe-src/expansion.yml
 
   "install driver":
     # Clone driver source code into the 'astrolabe-src/<driver-repo-name>' directory.
@@ -154,7 +177,7 @@ functions:
         # Next commands will exit with appropriate status
         continue_on_err: true
         env:
-          ATLAS_PROJECT_NAME: ${project}
+          ATLAS_PROJECT_NAME: ${ATLAS_PROJECT_NAME}
           CLUSTER_NAME_SALT: ${build_id}
           ATLAS_API_USERNAME: ${atlas_key}
           ATLAS_API_PASSWORD: ${atlas_secret}
@@ -190,7 +213,7 @@ functions:
       params:
         working_dir: astrolabe-src
         env:
-          ATLAS_PROJECT_NAME: ${project}
+          ATLAS_PROJECT_NAME: ${ATLAS_PROJECT_NAME}
           CLUSTER_NAME_SALT: ${build_id}
           ATLAS_API_USERNAME: ${atlas_key}
           ATLAS_API_PASSWORD: ${atlas_secret}
@@ -218,7 +241,7 @@ functions:
       params:
         working_dir: astrolabe-src
         env:
-          ATLAS_PROJECT_NAME: ${project}
+          ATLAS_PROJECT_NAME: ${ATLAS_PROJECT_NAME}
           CLUSTER_NAME_SALT: ${build_id}
           ATLAS_API_USERNAME: ${atlas_key}
           ATLAS_API_PASSWORD: ${atlas_secret}
@@ -228,6 +251,7 @@ functions:
           ATLAS_ADMIN_API_PASSWORD: ${atlas_admin_api_password}
         add_expansions_to_env: true
         script: |
+          set -eux
           # Only run after Atlas tasks.
           if [ "${ATLAS}" != "true" ]; then
             echo "Skipping Atlas cluster cleanup because it's not a Atlas task."
@@ -776,7 +800,7 @@ buildvariants:
   tasks:
     # Kind tasks can't run on Windows, so exclude them.
     - ".all !.kind"
-# TODO(BUILD-17806): GLIBC on Ubuntu 18 is too low (2.27) for Node 18 and Node 20 (2.28) 
+# TODO(BUILD-17806): GLIBC on Ubuntu 18 is too low (2.27) for Node 18 and Node 20 (2.28)
 - matrix_name: tests-node
   matrix_spec:
     driver:

--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -73,16 +73,10 @@ functions:
         add_expansions_to_env: true
         script: |
           # create a unique atlas project per task and execution.
-          # task_id has the structure $projectID_$variantName_$taskName_$commitHash_$createTime, which is unique per task per ci run per project.
-          # task_id is NOT unique across restarts of the same task though, so we include execution to ensure that it is unique for every restart too.
-          #
-          # the generated string is then transformed to satisfy Atlas cluster naming requirements
-          # - the string cannot be > 64 characters long, so we hash the name to shorten it and maintain its uniqueness (hashes do have collisions but infrequently
-          #   enough that hashing suffices here)
-          # - we convert it to hex encoding because cluster names must be alphanumeric (hyphens are allowed)
-          transform="process.stdout.write(require('crypto').createHash('md5').update(process.argv[1]).digest().toString('hex'))"
-          salt=$(node -e $transform "${task_id}-${execution}")
+          # use the timestamp so we can prune old projects.
+          # add a random suffix to differentiate clusters.
           timestamp=$(date +%s)
+          salt=$(node -e "process.stdout.write((Math.random() + 1).toString(36).substring(2))")
           cat <<EOT > expansion.yml
           ATLAS_PROJECT_NAME: "$project-$timestamp-$salt"
           EOT

--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -81,9 +81,10 @@ functions:
           #   enough that hashing suffices here)
           # - we convert it to hex encoding because cluster names must be alphanumeric (hyphens are allowed)
           transform="process.stdout.write(require('crypto').createHash('md5').update(process.argv[1]).digest().toString('hex'))"
-          unique_id=$(node -e $transform "${task_id}-${execution}")
+          salt=$(node -e $transform "${task_id}-${execution}")
+          timestamp=$(date +%s)
           cat <<EOT > expansion.yml
-          ATLAS_PROJECT_NAME: "$project-$unique_id"
+          ATLAS_PROJECT_NAME: "$project-$timestamp-$salt"
           EOT
     - command: expansions.update
       params:

--- a/astrolabe/atlas_runner.py
+++ b/astrolabe/atlas_runner.py
@@ -72,11 +72,7 @@ class AtlasTestCase:
         # Initialize wrapper class for running workload executor.
         self.workload_runner = DriverWorkloadSubprocessRunner()
 
-        # Generate a unique project name with timestamp & random suffix
-        current_timestamp = int(_time.time())
-        timestamp_suffix = '-' + str(current_timestamp)            
-        random_suffix = '-' + str(int(random.random() * 1_000_000_000))
-        self.project_name = self.config.project_name + timestamp_suffix + random_suffix
+        self.project_name = self.config.project_name
         self.project = None
 
     @property
@@ -116,7 +112,7 @@ class AtlasTestCase:
         Initialize a cluster with the configuration required by the test
         specification.
         """
-        
+
         if no_create:
             try:
                 # If --no-create was specified and the cluster exists, skip
@@ -130,7 +126,7 @@ class AtlasTestCase:
                     LOGGER.warn('Cluster was not found, will create one')
             except AssertionError as exc:
                 LOGGER.warn('Configuration did not match: %s. Recreating the cluster' % exc)
-            
+
         LOGGER.info("Initializing cluster {!r}".format(self.cluster_name))
 
         cluster_config = self.spec.initialConfiguration.\
@@ -158,7 +154,7 @@ class AtlasTestCase:
     def run(self, persist_cluster=False, startup_time=1):
         LOGGER.info("Running test {!r} on cluster {!r}".format(
             self.id, self.cluster_name))
-        
+
         # Step-1: sanity-check the cluster configuration.
         self.verify_cluster_configuration_matches(self.spec.initialConfiguration)
 
@@ -177,9 +173,9 @@ class AtlasTestCase:
             for operation in self.spec.operations:
                 if len(operation) != 1:
                     raise ValueError("Operation must have exactly one key: %s" % operation)
-                    
+
                 op_name, op_spec = list(operation.items())[0]
-                
+
                 if op_name == 'setClusterConfiguration':
                     # Step-3: begin maintenance routine.
                     final_config = op_spec
@@ -201,7 +197,7 @@ class AtlasTestCase:
                     self.wait_for_idle()
                     self.verify_cluster_configuration_matches(final_config)
                     LOGGER.info("Cluster maintenance complete")
-                    
+
                 elif op_name == 'testFailover':
                     timer = Timer()
                     timer.start()
@@ -235,48 +231,48 @@ class AtlasTestCase:
 
                     self.wait_for_planning(start_time)
                     self.wait_for_idle()
-                    
+
                 elif op_name == 'sleep':
                     _time.sleep(op_spec)
-                    
+
                 elif op_name == 'waitForIdle':
                     self.wait_for_idle()
-                    
+
                 elif op_name == 'restartVms':
                     rv = self.admin_client.nds.groups[self.project.id].clusters[self.cluster_name].reboot.post(api_version='private')
-                    
+
                     self.wait_for_idle()
-                    
+
                 elif op_name == 'assertPrimaryRegion':
                     region = op_spec['region']
-                    
+
                     cluster_config = self.cluster_url.get().data
                     timer = Timer()
                     timer.start()
                     timeout = op_spec.get('timeout', 90)
-                    
+
                     with mongo_client(self.get_connection_string()) as mc:
                         while True:
                             rsc = mc.admin.command('replSetGetConfig')
                             member = [m for m in rsc['config']['members']
                                 if m['horizons']['PUBLIC'] == '%s:%s' % mc.primary][0]
                             member_region = member['tags']['region']
-                        
+
                             if region == member_region:
                                 break
-                                
+
                             if timer.elapsed > timeout:
                                 raise Exception("Primary in cluster not in expected region '%s' (actual region '%s')" % (region, member_region))
                             else:
                                 sleep(5)
-                    
+
                 else:
                     raise Exception('Unrecognized operation %s' % op_name)
 
             # Wait 10 seconds to ensure that the driver is not experiencing any
             # errors after the maintenance has concluded.
             sleep(10)
-            
+
             # Step-5: interrupt driver workload and capture streams
             stats = self.workload_runner.stop()
 
@@ -308,7 +304,7 @@ class AtlasTestCase:
                 LOGGER.info("SUCCEEDED: {!r}".format(self.id))
                 # Directly log output of successful tests as xunit output
                 # is only visible for failed tests.
-            
+
             # Step 7: download logs asynchronously and delete cluster.
             # TODO: https://github.com/mongodb-labs/drivers-atlas-testing/issues/4
             if not persist_cluster:
@@ -319,7 +315,7 @@ class AtlasTestCase:
             return junit_test
         finally:
             self.workload_runner.terminate()
-        
+
     def wait_for_idle(self):
         # Small delay to account for Atlas not updating cluster state
         # synchronously potentially in all maintenance operations
@@ -350,7 +346,7 @@ class AtlasTestCase:
             if actual_state == wanted_state:
                 ok = True
                 break
-            
+
             msg = "Cluster %s: current state: %s; wanted state: %s; waited for %.1f sec" % (self.cluster_name, actual_state, wanted_state, timer.elapsed)
             now = monotonic()
             # Notify once a minute, see DRIVERS-2013.
@@ -361,7 +357,7 @@ class AtlasTestCase:
                 LOGGER.debug(msg)
         if not ok:
             raise PollingTimeoutError("Polling timed out after %s seconds" % timeout)
-            
+
     def wait_for_planning(self, start_time):
         timer = Timer()
         timer.start()
@@ -375,7 +371,7 @@ class AtlasTestCase:
             if planning_time > start_time:
                 ok = True
                 break
-            
+
             msg = "Cluster %s: last planned: %s; wanted after: %s; waited for %.1f sec" % (self.cluster_name, planning_time, start_time, timer.elapsed)
             now = monotonic()
             # Notify once a minute, see DRIVERS-2013.
@@ -384,9 +380,9 @@ class AtlasTestCase:
                 LOGGER.info(msg)
             else:
                 LOGGER.debug(msg)
-            
+
             _time.sleep(5)
-        
+
         if not ok:
             raise PollingTimeoutError("Timed out waiting for planning after %s seconds" % timeout)
 
@@ -428,7 +424,7 @@ class SpecTestRunnerBase:
 
         # Step-2: clean old projects with same name base from organization.
         if not no_create:
-            self.clean_old_projects(org.id)                             
+            self.clean_old_projects(org.id)
 
         with open(workload_file) as f:
             workload = JSONObject.from_dict(yaml.safe_load(f))
@@ -453,7 +449,7 @@ class SpecTestRunnerBase:
                 workload=workload,
                 configuration=self.config)
             self.cases.append(atlas_test_case)
-        
+
             # Set up Atlas for tests.
             # Step-1: check that the project exists or else create it.
             pro_name = atlas_test_case.project_name
@@ -499,7 +495,7 @@ class SpecTestRunnerBase:
                     int(project_timestamp) < current_timestamp - self.project_expiration_threshold_seconds:
                     try:
                         delete_project(client=self.client, project_id=project.id)
-                        LOGGER.info("Successfully deleted project {!r}, id: {!r}".format(project.name, project.id)) 
+                        LOGGER.info("Successfully deleted project {!r}, id: {!r}".format(project.name, project.id))
                     except AtlasApiError as esc:
                         # the project may have been deleted by another test just now.
                         if esc.error_code == 'GROUP_NOT_FOUND':

--- a/astrolabe/cli.py
+++ b/astrolabe/cli.py
@@ -625,25 +625,6 @@ def delete_test_cluster(ctx, spec_test_file, workload_file, org_id, project_name
     else:
         print(f"Project {project_name} not found!")
 
-    # Step-3: delete the project.
-    msg = f"Deleting project {project_name}..."
-    if project:
-        print(msg)
-        while 1:
-            try:
-                client.groups[project.id].delete().data
-                print(f"{msg} done.")
-                break
-            except AtlasApiBaseError as e:
-                # https://www.mongodb.com/docs/atlas/reference/api-errors/
-                # Cannot close group while it has active clusters; please terminate all clusters.
-                if e.error_code == "CANNOT_CLOSE_GROUP_ACTIVE_ATLAS_CLUSTERS":
-                    print(e.detail, "sleeping 10 seconds...")
-                    time.sleep(10)
-                else:
-                    pprint(e.detail)
-                    break
-
 
 @atlas_tests.command('run')
 @click.argument("spec_tests_directory", type=click.Path(

--- a/astrolabe/cli.py
+++ b/astrolabe/cli.py
@@ -14,6 +14,7 @@
 
 import logging
 import os
+import time
 import unittest
 from pprint import pprint
 from urllib.parse import unquote_plus
@@ -143,7 +144,7 @@ def cli(ctx, atlas_base_url, atlas_api_username,
             timeout=http_timeout)
     else:
         admin_client = None
-    
+
     ctx.obj = ContextStore(client, admin_client)
 
     # Configure logging.
@@ -225,9 +226,11 @@ def delete_all_projects(ctx, org_id):
     """Delete all Atlas Projects in organization."""
     projects_res = cmd.list_projects_in_org(client=ctx.obj.client, org_id=org_id)
     for project in projects_res['results']:
-        cmd.delete_project(client=ctx.obj.client, project_id=project.id)
-        LOGGER.info("Successfully deleted project {!r}, id: {!r}".format(project.name, project.id))
-
+        try:
+            cmd.delete_project(client=ctx.obj.client, project_id=project.id)
+            LOGGER.info("Successfully deleted project {!r}, id: {!r}".format(project.name, project.id))
+        except Exception as e:
+            LOGGER.exception(e)
 
 @atlas_projects.command('get-one')
 @ATLASPROJECTNAME_OPTION
@@ -558,7 +561,7 @@ def get_logs_cmd(ctx, spec_test_file, workload_file, org_id, project_name,
     Retrieves logs for the cluster and saves them in logs.tar.gz in the
     current working directory.
     """
-    
+
     if only_on_failure:
         if os.path.exists('status'):
             with open('status') as fp:
@@ -574,7 +577,7 @@ def get_logs_cmd(ctx, spec_test_file, workload_file, org_id, project_name,
     cluster_name = get_cluster_name(
         get_test_name(spec_test_file, workload_file),
         cluster_name_salt)
-    
+
     organization = cmd.get_organization_by_id(
         client=ctx.obj.client,
         org_id=org_id)
@@ -604,17 +607,42 @@ def delete_test_cluster(ctx, spec_test_file, workload_file, org_id, project_name
     cluster_name = get_cluster_name(
         get_test_name(spec_test_file, workload_file),
         cluster_name_salt)
+    msg = f"Deleting cluster {cluster_name} in project {project_name}..."
+    print(msg)
 
     # Step-2: delete the cluster.
+    client =ctx.obj.client
     organization = cmd.get_organization_by_id(
-        client=ctx.obj.client, org_id=org_id)
+        client=client, org_id=org_id)
     project = cmd.get_project(
-        client=ctx.obj.client, project_name=project_name, organization_id=organization.id)
+        client=client, project_name=project_name, organization_id=organization.id)
     if project:
         try:
-            ctx.obj.client.groups[project.id].clusters[cluster_name].delete()
-        except AtlasApiBaseError:
-            pass
+            client.groups[project.id].clusters[cluster_name].delete().data
+            print(f"{msg} done.")
+        except AtlasApiBaseError as e:
+            pprint(e)
+    else:
+        print(f"Project {project_name} not found!")
+
+    # Step-3: delete the project.
+    msg = f"Deleting project {project_name}..."
+    if project:
+        print(msg)
+        while 1:
+            try:
+                client.groups[project.id].delete().data
+                print(f"{msg} done.")
+                break
+            except AtlasApiBaseError as e:
+                # https://www.mongodb.com/docs/atlas/reference/api-errors/
+                # Cannot close group while it has active clusters; please terminate all clusters.
+                if e.error_code == "CANNOT_CLOSE_GROUP_ACTIVE_ATLAS_CLUSTERS":
+                    print(e.detail, "sleeping 10 seconds...")
+                    time.sleep(10)
+                else:
+                    pprint(e.detail)
+                    break
 
 
 @atlas_tests.command('run')

--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,7 @@ else:
 install_requires = [
     'click>=7,<8', 'requests>=2,<3',
     'pymongo>=3.10,<4', 'dnspython>=1.16,<2',
-    'pyyaml>=5,<6', 'tabulate>=0.8,<0.9',
+    'pyyaml>=5,<7', 'tabulate>=0.8,<0.9',
     'numpy<2',
     'junitparser>=1,<2']
 if sys.platform == 'win32':


### PR DESCRIPTION
Use a timestamp in the project name so the `clean_old_projects` function can remove previous projects after the fact.