### PR TITLE
DRIVERS-2726: Use Ubuntu 22.04

### DIFF
--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -464,105 +464,105 @@ tasks:
   # Workload executor validation task (patch-only).
   - name: validate-workload-executor
     patch_only: true
-    tags: ["all"]
+    tags: ["all", "validate"]
     commands:
       - func: "validate executor"
 
   # Atlas test tasks
   # ================
   - name: atlas-retryReads-move-sharded
-    tags: ["all"]
+    tags: ["all", "atlas"]
     commands:
       - func: "run atlas test"
         vars:
           WORKLOAD_FILE: workloads/retryReads.yml
           TEST_FILE: tests/atlas/move-sharded.yml
   - name: atlas-retryReads-move
-    tags: ["all"]
+    tags: ["all", "atlas"]
     commands:
       - func: "run atlas test"
         vars:
           WORKLOAD_FILE: workloads/retryReads.yml
           TEST_FILE: tests/atlas/move.yml
   - name: atlas-retryReads-primaryRemoval
-    tags: ["all"]
+    tags: ["all", "atlas"]
     commands:
       - func: "run atlas test"
         vars:
           WORKLOAD_FILE: workloads/retryReads.yml
           TEST_FILE: tests/atlas/primaryRemoval.yml
   - name: atlas-retryReads-primaryTakeover
-    tags: ["all"]
+    tags: ["all", "atlas"]
     commands:
       - func: "run atlas test"
         vars:
           WORKLOAD_FILE: workloads/retryReads.yml
           TEST_FILE: tests/atlas/primaryTakeover.yml
   - name: atlas-retryReads-processRestart-sharded
-    tags: ["all"]
+    tags: ["all", "atlas"]
     commands:
       - func: "run atlas test"
         vars:
           WORKLOAD_FILE: workloads/retryReads.yml
           TEST_FILE: tests/atlas/processRestart-sharded.yml
   - name: atlas-retryReads-processRestart
-    tags: ["all"]
+    tags: ["all", "atlas"]
     commands:
       - func: "run atlas test"
         vars:
           WORKLOAD_FILE: workloads/retryReads.yml
           TEST_FILE: tests/atlas/processRestart.yml
   - name: atlas-retryReads-resizeCluster
-    tags: ["all"]
+    tags: ["all", "atlas"]
     commands:
       - func: "run atlas test"
         vars:
           WORKLOAD_FILE: workloads/retryReads.yml
           TEST_FILE: tests/atlas/resizeCluster.yml
   - name: atlas-retryReads-testFailover-sharded
-    tags: ["all"]
+    tags: ["all", "atlas"]
     commands:
       - func: "run atlas test"
         vars:
           WORKLOAD_FILE: workloads/retryReads.yml
           TEST_FILE: tests/atlas/testFailover-sharded.yml
   - name: atlas-retryReads-testFailover
-    tags: ["all"]
+    tags: ["all", "atlas"]
     commands:
       - func: "run atlas test"
         vars:
           WORKLOAD_FILE: workloads/retryReads.yml
           TEST_FILE: tests/atlas/testFailover.yml
   - name: atlas-retryReads-toggleServerSideJS
-    tags: ["all"]
+    tags: ["all", "atlas"]
     commands:
       - func: "run atlas test"
         vars:
           WORKLOAD_FILE: workloads/retryReads.yml
           TEST_FILE: tests/atlas/toggleServerSideJS.yml
   - name: atlas-retryReads-vmRestart-sharded
-    tags: ["all"]
+    tags: ["all", "atlas"]
     commands:
       - func: "run atlas test"
         vars:
           WORKLOAD_FILE: workloads/retryReads.yml
           TEST_FILE: tests/atlas/vmRestart-sharded.yml
   - name: atlas-retryReads-vmRestart
-    tags: ["all"]
+    tags: ["all", "atlas"]
     commands:
       - func: "run atlas test"
         vars:
           WORKLOAD_FILE: workloads/retryReads.yml
           TEST_FILE: tests/atlas/vmRestart.yml
   - name: atlas-retryWrites-resizeCluster
-    tags: ["all"]
+    tags: ["all", "atlas"]
     commands:
       - func: "run atlas test"
         vars:
           WORKLOAD_FILE: workloads/retryWrites.yml
           TEST_FILE: tests/atlas/resizeCluster.yml
   - name: atlas-retryWrites-toggleServerSideJS
-    tags: ["all"]
+    tags: ["all", "atlas"]
     commands:
       - func: "run atlas test"
         vars:
@@ -914,8 +914,8 @@ buildvariants:
       - "dotnet-sync-net6"
   display_name: "${driver} ${platform} ${runtime}"
   tasks:
-    # Only run the Kind tasks for the .NET driver on Linux.
-    - ".kind"
+    # Don't run Atlas tasks for the .NET driver on Linux.
+    - ".all !.atlas"
 - matrix_name: "tests-go"
   matrix_spec:
     driver: ["go-master"]

--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -120,12 +120,13 @@ functions:
           python -m pip install -q pre-commit check-manifest
           pre-commit run --all-files --hook-stage=manual
           check-manifest -v
- 
+
   "validate executor":
     # Run a MongoDB instance locally.
     - command: shell.exec
       type: setup
       params:
+        include_expansions_in_env: ["MONGODB_VERSION"]
         working_dir: astrolabe-src
         script: |
           sh .evergreen/run-mongodb.sh
@@ -438,7 +439,7 @@ functions:
 pre:
   - func: "fetch source"
   - func: "install astrolabe"
-  - func: "install driver"  
+  - func: "install driver"
 
 # Functions to run after the test.
 post:
@@ -739,6 +740,8 @@ axes:
           # Set locale to unicode - needed for astrolabe to function correctly.
           LC_ALL: "C.UTF-8"
           LANG: "C.UTF-8"
+          # Use MongoDB 6.0 as rapid isn't available on 18.04 anymore
+          MONGODB_VERSION: "6.0"
       - id: ubuntu-22.04
         display_name: "Ubuntu 22.04"
         run_on: ubuntu2204-drivers-atlas-testing
@@ -943,5 +946,5 @@ buildvariants:
     driver: ["c-master"]
     platform: ["ubuntu-22.04"]
     runtime: ["c-gcc", "c-clang"]
-  tasks: 
+  tasks:
     - ".all"

--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -773,6 +773,10 @@ axes:
         display_name: CPython-3.7-Windows
         variables:
           PYTHON_BINARY: "C:/python/Python37/python.exe"
+      - id: ruby-32
+        display_name: Ruby 3.2
+        variables:
+          RVM_RUBY: "ruby-3.2"
       - id: node-16
         display_name: Node v16
         variables:
@@ -840,8 +844,8 @@ buildvariants:
 - matrix_name: "tests-ruby"
   matrix_spec:
     driver: ["ruby-master"]
-    platform: ubuntu-18.04
-    runtime: python39
+    platform: ubuntu-22.04
+    runtime: ruby-32
   display_name: "${driver} ${platform} ${runtime}"
   tasks:
     - ".all"

--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -846,7 +846,7 @@ buildvariants:
 - matrix_name: "tests-python"
   matrix_spec:
     driver: ["pymongo-master"]
-    platform: ["ubuntu-18.04"]
+    platform: ["ubuntu-22.04"]
     runtime: ["python39"]
   display_name: "${driver} ${platform} ${runtime}"
   tasks:
@@ -916,7 +916,7 @@ buildvariants:
 - matrix_name: "tests-go"
   matrix_spec:
     driver: ["go-master"]
-    platform: ubuntu-18.04
+    platform: ubuntu-22.04
     runtime: go-20
   display_name: "${driver} ${platform} ${runtime}"
   tasks:
@@ -932,7 +932,7 @@ buildvariants:
 - matrix_name: "tests-rust"
   matrix_spec:
     driver: ["rust-main"]
-    platform: ubuntu-18.04
+    platform: ubuntu-22.04
     runtime: rust-latest
   display_name: "${driver} ${platform} ${runtime}"
   tasks:
@@ -941,7 +941,7 @@ buildvariants:
   display_name: "${driver} ${platform} ${runtime}"
   matrix_spec:
     driver: ["c-master"]
-    platform: ["ubuntu-18.04"]
+    platform: ["ubuntu-22.04"]
     runtime: ["c-gcc", "c-clang"]
   tasks: 
     - ".all"

--- a/.evergreen/run-mongodb.sh
+++ b/.evergreen/run-mongodb.sh
@@ -3,7 +3,7 @@ set -o xtrace
 
 # User configurable-options
 # Each distro in the download script has a latest download.
-export MONGODB_VERSION="rapid"
+export MONGODB_VERSION=${MONGODB_VERSION:-rapid}
 export TOPOLOGY="server"
 
 # Setup variables


### PR DESCRIPTION
DRIVERS-2726

I skipped node 16 as well as the .NET driver as that had issues in my testing and should be updated separately. I ran a patch with a single Atlas and a single Kind task, which all passed successfully: https://spruce.mongodb.com/version/6530f40e9ccd4e89b0cdcf5c