### PR TITLE
DRIVERS-2786 Enable retryable writes for kind-retryWrites-scaleDown test.

### DIFF
--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -611,7 +611,7 @@ tasks:
       - func: "run kind test"
         vars:
           TEST_FILE: tests/kubernetes/kind/scaleDown.yml
-          WORKLOAD_FILE: workloads/writes.yml
+          WORKLOAD_FILE: workloads/retryWrites.yml
       - func: "retrieve kind logs"
       - func: "delete kind cluster"
 


### PR DESCRIPTION
[DRIVERS-2786](https://jira.mongodb.org/browse/DRIVERS-2786)

Use the `retryWrites.yml` workload file for the "kind-retryWrites-scaleDown" task.