### PR TITLE
GODRIVER-3069 Update Go integration to use V1

### DIFF
--- a/integrations/go/install-driver.sh
+++ b/integrations/go/install-driver.sh
@@ -7,6 +7,6 @@ cd integrations/$DRIVER_DIRNAME
 
 export PATH=$GOROOT/bin:$PATH
 
-go get go.mongodb.org/mongo-driver@master
+go get go.mongodb.org/mongo-driver@v1
 go mod tidy
 go test -c workload_executor_test.go -o executor


### PR DESCRIPTION
GODRIVER-3069

The cmd package is internalized on the master branch in GODRIVER-2724 . The Go integration needs to be updated to use v1.