### PR TITLE
DRIVERS-2729: Make Astrolabe failure-to-cleanup more obvious

### DIFF
--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -5,8 +5,9 @@
 # Run previous commits to pinpoint a failure's origin.
 stepback: true
 
-# Fail builds when pre tasks fail.
+# Fail builds when pre and post tasks fail.
 pre_error_fails_task: true
+post_error_fails_task: true
 
 # Mark failures other than test failures with a purple box.
 command_type: system

--- a/astrolabe/cli.py
+++ b/astrolabe/cli.py
@@ -627,8 +627,9 @@ def delete_test_cluster(ctx, spec_test_file, workload_file, org_id, project_name
             print(f"{msg} done.")
         except AtlasApiBaseError as e:
             pprint(e)
+            raise
     else:
-        print(f"Project {project_name} not found!")
+        raise AtlasClientError(f"Project {project_name} not found!")
 
 
 @atlas_tests.command('run')


### PR DESCRIPTION
## Changes in this PR
Following the description on [DRIVERS-2729](https://jira.mongodb.org/browse/DRIVERS-2729), I've: 
* Added `post_error_fails_task = true` 
* Re-raise the exception on failures

## Callout
what would be the expected exception type I'd raise for when the project name is not found? 