### PR TITLE
Revert "DRIVERS-2729: Make Astrolabe failure-to-cleanup more obvious"

### DIFF
--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -5,9 +5,8 @@
 # Run previous commits to pinpoint a failure's origin.
 stepback: true
 
-# Fail builds when pre and post tasks fail.
+# Fail builds when pre tasks fail.
 pre_error_fails_task: true
-post_error_fails_task: true
 
 # Mark failures other than test failures with a purple box.
 command_type: system

--- a/astrolabe/cli.py
+++ b/astrolabe/cli.py
@@ -720,9 +720,8 @@ def delete_test_cluster(
             print(f"{msg} done.")
         except AtlasApiBaseError as e:
             pprint(e)
-            raise
     else:
-        raise AtlasClientError(f"Project {project_name} not found!")
+        print(f"Project {project_name} not found!")
 
 
 @atlas_tests.command("run")


### PR DESCRIPTION
Reverts mongodb-labs/drivers-atlas-testing#188

Looks like `post_error_fails_task: true` is reporting the `upload server logs` failure in the post step to fail. I'll revert until I can remedy this issue. 