### PR TITLE
Rename references to old branch name

### DIFF
--- a/docs/faq.md
+++ b/docs/faq.md
@@ -36,7 +36,7 @@ MongoDB Atlas restricts the number of clusters in an Atlas Project to
 25. Since [this
 project](https://github.com/mongodb-labs/drivers-atlas-testing) runs the
 entire build matrix in its in [evergreen
-configuration](https://github.com/mongodb-labs/drivers-atlas-testing/blob/master/.evergreen/config.yml)
+configuration](https://github.com/mongodb-labs/drivers-atlas-testing/blob/main/.evergreen/config.yml)
 under a single Atlas project, it often ends up running into this
 limitation which causes hard-to-diagnose test failures (see
 [#45](https://github.com/mongodb-labs/drivers-atlas-testing/issues/45),

--- a/docs/integration-guide.md
+++ b/docs/integration-guide.md
@@ -70,7 +70,7 @@ shell script such that exposes the API desired by the
 
 For example, PyMongo's `astrolabe` integration uses this pattern to
 implement its [workload
-executor](https://github.com/mongodb-labs/drivers-atlas-testing/blob/master/integrations/python/pymongo/workload-executor).
+executor](https://github.com/mongodb-labs/drivers-atlas-testing/blob/main/integrations/python/pymongo/workload-executor).
 
 ### Testing/validating a workload executor script
 

--- a/docs/spec-workload-executor.md
+++ b/docs/spec-workload-executor.md
@@ -272,7 +272,7 @@ function workloadRunner(connectionString: string, workload: object): void {
 ## Reference Implementation
 
 [Ruby's workload
-executor](https://github.com/mongodb-labs/drivers-atlas-testing/blob/master/integrations/ruby/workload-executor)
+executor](https://github.com/mongodb-labs/drivers-atlas-testing/blob/main/integrations/ruby/workload-executor)
 serves as the reference implementation of the script described by this
 specification.
 


### PR DESCRIPTION
This follows the recent renaming of the default branch in GitHub.