### PR TITLE
Use bash shell where not already in use

### DIFF
--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -103,7 +103,7 @@ functions:
         add_expansions_to_env: true
         script: |
           if [ "Windows_NT" = "$OS" ]; then
-            C:/cygwin/bin/sh integrations/${DRIVER_DIRNAME}/install-driver.sh
+            C:/cygwin/bin/bash integrations/${DRIVER_DIRNAME}/install-driver.sh
           else
             ./integrations/${DRIVER_DIRNAME}/install-driver.sh
           fi
@@ -129,7 +129,7 @@ functions:
         include_expansions_in_env: ["MONGODB_VERSION"]
         working_dir: astrolabe-src
         script: |
-          sh .evergreen/run-mongodb.sh
+          .evergreen/run-mongodb.sh
     # Validate the workload executor against the local MongoDB instance.
     - command: subprocess.exec
       type: test

--- a/.evergreen/run-mongodb.sh
+++ b/.evergreen/run-mongodb.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env bash
 set -o xtrace
 
 # User configurable-options
@@ -32,4 +32,4 @@ for i in $(find ${DRIVERS_TOOLS}/.evergreen -name \*.sh); do
 done
 
 # Run mongo-orchestration
-sh $DRIVERS_TOOLS/.evergreen/run-orchestration.sh
+$DRIVERS_TOOLS/.evergreen/run-orchestration.sh

--- a/integrations/python/pymongo/install-driver.sh
+++ b/integrations/python/pymongo/install-driver.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env bash
 set -o xtrace
 
 "$PYTHON_BINARY" --version

--- a/kubernetes/kind/create.sh
+++ b/kubernetes/kind/create.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env bash
 set -o xtrace
 set -e
 


### PR DESCRIPTION
In #211 I observed failures when running the validator. This seems to happen because Astrolabe uses `sh` to call run-mongodb.sh and subsequently call run-orchestration.sh. This PR changes scripts to use `bash` where not already in use.

Note: the PHP failure is fixed by #211, but I wanted to separate the pull requests. The .NET failure has been a consistent failure for a while.