### PR TITLE
DRIVERS-2964 Log cluster state for 30 minutes after assertPrimaryRegion failure.

### DIFF
--- a/astrolabe/atlas_runner.py
+++ b/astrolabe/atlas_runner.py
@@ -309,11 +309,13 @@ class AtlasTestCase:
                     # See https://jira.mongodb.org/browse/PRODTRIAGE-1232 for
                     # more context.
                     if not ok:
+                        msg = f"Primary node ({mc.primary}) not in expected region '{region}' within {timeout}s (current region: '{member_region}'; all members: {members})"
+                        LOGGER.error(msg)
+
+                        LOGGER.info("Logging cluster state for 30m after assertPrimaryRegion failure.")
                         self.log_cluster_status(timeout=1800)
 
-                        raise Exception(
-                            f"Primary node ({mc.primary}) not in expected region '{region}' within {timeout}s (current region: '{member_region}'; all members: {members})"
-                        )
+                        raise Exception(msg)
 
                     LOGGER.debug(
                         f"Waited for {timer.elapsed}s for primary node to be in region '{region}'"


### PR DESCRIPTION
[DRIVERS-2964](https://jira.mongodb.org/browse/DRIVERS-2964)

We want to collect more information about the cluster state when the "assertPrimaryRegion" step fails, so instead of immediately stopping the job, log the cluster state every 5 seconds for the next 30 minutes (then stop the job).