### PR TITLE
Remove code specific to symfony/phpunit-bridge to use PHPUnit directly from vendors

### DIFF
--- a/integrations/php/install-driver.sh
+++ b/integrations/php/install-driver.sh
@@ -82,8 +82,5 @@ php --ri mongodb
 install_composer
 php composer.phar update --working-dir=${PHPLIB_PATH}
 
-# Allow simple-phpunit to install its own PHPUnit dependencies
-php ${PHPLIB_PATH}/vendor/bin/simple-phpunit install
-
 # The symlink helps to include the library and tests with a simple path
 ln -s ${PHPLIB_PATH}/vendor ./vendor

--- a/integrations/php/workload-executor.php
+++ b/integrations/php/workload-executor.php
@@ -8,7 +8,6 @@ use function MongoDB\BSON\fromJSON;
 use function MongoDB\BSON\toPHP;
 
 require_once __DIR__ . '/vendor/autoload.php';
-require_once __DIR__ . '/vendor/bin/.phpunit/phpunit/vendor/autoload.php';
 
 class Logger
 {


### PR DESCRIPTION
Follow https://github.com/mongodb/mongo-php-library/pull/1413