### PR TITLE
DRIVERS-3020 Remove use of Evergreen secrets in Atlas Testing

### DIFF
--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -218,10 +218,8 @@ functions:
         env:
           ATLAS_PROJECT_NAME: ${ATLAS_PROJECT_NAME}
           ATLAS_PROJECT_BASE_NAME: ${project}
+          CLUSTER_NAME_SALT: ${build_id}
         script: |
-          pwd
-          ls
-          source secrets-export.sh
           astrolabevenv/${PYTHON_BIN_DIR}/astrolabe atlas-tests \
             run-one ${TEST_FILE} \
             --workload-file ${WORKLOAD_FILE} \

--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -114,6 +114,7 @@ functions:
       type: setup
       params:
         binary: bash
+        working_dir: astrolabe-src
         args: [.evergreen/setup-secrets.sh]
 
   "lint and format":
@@ -217,15 +218,8 @@ functions:
         env:
           ATLAS_PROJECT_NAME: ${ATLAS_PROJECT_NAME}
           ATLAS_PROJECT_BASE_NAME: ${project}
-          CLUSTER_NAME_SALT: ${build_id}
-          ATLAS_API_USERNAME: ${atlas_key}
-          ATLAS_API_PASSWORD: ${atlas_secret}
-          ATLAS_API_BASE_URL: ${atlas_url}
-          ATLAS_ORGANIZATION_ID: ${atlas_organization_id}
-          ATLAS_ADMIN_API_USERNAME: ${atlas_admin_api_username}
-          ATLAS_ADMIN_API_PASSWORD: ${atlas_admin_api_password}
-        add_expansions_to_env: true
         script: |
+          source secrets-export.sh
           astrolabevenv/${PYTHON_BIN_DIR}/astrolabe atlas-tests \
             run-one ${TEST_FILE} \
             --workload-file ${WORKLOAD_FILE} \
@@ -255,14 +249,8 @@ functions:
           ATLAS_PROJECT_NAME: ${ATLAS_PROJECT_NAME}
           ATLAS_PROJECT_BASE_NAME: ${project}
           CLUSTER_NAME_SALT: ${build_id}
-          ATLAS_API_USERNAME: ${atlas_key}
-          ATLAS_API_PASSWORD: ${atlas_secret}
-          ATLAS_API_BASE_URL: ${atlas_url}
-          ATLAS_ORGANIZATION_ID: ${atlas_organization_id}
-          ATLAS_ADMIN_API_USERNAME: ${atlas_admin_api_username}
-          ATLAS_ADMIN_API_PASSWORD: ${atlas_admin_api_password}
-        add_expansions_to_env: true
         script: |
+          source secrets-export.sh
           # Only run after Atlas tasks.
           if [ "${ATLAS}" != "true" ]; then
             echo "Skipping Atlas logs download because it's not a Atlas task."
@@ -284,15 +272,10 @@ functions:
           ATLAS_PROJECT_NAME: ${ATLAS_PROJECT_NAME}
           ATLAS_PROJECT_BASE_NAME: ${project}
           CLUSTER_NAME_SALT: ${build_id}
-          ATLAS_API_USERNAME: ${atlas_key}
-          ATLAS_API_PASSWORD: ${atlas_secret}
-          ATLAS_API_BASE_URL: ${atlas_url}
-          ATLAS_ORGANIZATION_ID: ${atlas_organization_id}
-          ATLAS_ADMIN_API_USERNAME: ${atlas_admin_api_username}
-          ATLAS_ADMIN_API_PASSWORD: ${atlas_admin_api_password}
-        add_expansions_to_env: true
         script: |
           set -eux
+          source secrets-export.sh
+
           # Only run after Atlas tasks.
           if [ "${ATLAS}" != "true" ]; then
             echo "Skipping Atlas cluster cleanup because it's not a Atlas task."

--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -222,6 +222,7 @@ functions:
           ATLAS_ADMIN_API_USERNAME: ${atlas_admin_api_username}
           ATLAS_ADMIN_API_PASSWORD: ${atlas_admin_api_password}
           CLUSTER_NAME_SALT: ${build_id}
+        include_expansions_in_env: [DRIVER_DIRNAME]
         script: |
           source secrets-export.sh
           astrolabevenv/${PYTHON_BIN_DIR}/astrolabe atlas-tests \

--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -220,6 +220,7 @@ functions:
           ATLAS_PROJECT_BASE_NAME: ${project}
           CLUSTER_NAME_SALT: ${build_id}
         script: |
+          source secrets-export.sh
           astrolabevenv/${PYTHON_BIN_DIR}/astrolabe atlas-tests \
             run-one ${TEST_FILE} \
             --workload-file ${WORKLOAD_FILE} \

--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -213,6 +213,7 @@ functions:
       type: test
       params:
         working_dir: astrolabe-src
+        shell: bash
         # Next commands will exit with appropriate status
         continue_on_err: true
         env:
@@ -246,6 +247,7 @@ functions:
       type: setup
       params:
         working_dir: astrolabe-src
+        shell: bash
         env:
           ATLAS_PROJECT_NAME: ${ATLAS_PROJECT_NAME}
           ATLAS_PROJECT_BASE_NAME: ${project}
@@ -269,6 +271,7 @@ functions:
       type: setup
       params:
         working_dir: astrolabe-src
+        shell: bash
         env:
           ATLAS_PROJECT_NAME: ${ATLAS_PROJECT_NAME}
           ATLAS_PROJECT_BASE_NAME: ${project}

--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -219,6 +219,8 @@ functions:
           ATLAS_PROJECT_NAME: ${ATLAS_PROJECT_NAME}
           ATLAS_PROJECT_BASE_NAME: ${project}
         script: |
+          pwd
+          ls
           source secrets-export.sh
           astrolabevenv/${PYTHON_BIN_DIR}/astrolabe atlas-tests \
             run-one ${TEST_FILE} \

--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -219,6 +219,8 @@ functions:
         env:
           ATLAS_PROJECT_NAME: ${ATLAS_PROJECT_NAME}
           ATLAS_PROJECT_BASE_NAME: ${project}
+          ATLAS_ADMIN_API_USERNAME: ${atlas_admin_api_username}
+          ATLAS_ADMIN_API_PASSWORD: ${atlas_admin_api_password}
           CLUSTER_NAME_SALT: ${build_id}
         script: |
           source secrets-export.sh
@@ -251,6 +253,8 @@ functions:
         env:
           ATLAS_PROJECT_NAME: ${ATLAS_PROJECT_NAME}
           ATLAS_PROJECT_BASE_NAME: ${project}
+          ATLAS_ADMIN_API_USERNAME: ${atlas_admin_api_username}
+          ATLAS_ADMIN_API_PASSWORD: ${atlas_admin_api_password}
           CLUSTER_NAME_SALT: ${build_id}
         script: |
           source secrets-export.sh
@@ -275,6 +279,8 @@ functions:
         env:
           ATLAS_PROJECT_NAME: ${ATLAS_PROJECT_NAME}
           ATLAS_PROJECT_BASE_NAME: ${project}
+          ATLAS_ADMIN_API_USERNAME: ${atlas_admin_api_username}
+          ATLAS_ADMIN_API_PASSWORD: ${atlas_admin_api_password}
           CLUSTER_NAME_SALT: ${build_id}
         script: |
           set -eux

--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -109,6 +109,13 @@ functions:
             ./integrations/${DRIVER_DIRNAME}/install-driver.sh
           fi
 
+  "setup secrets":
+    - command: subprocess.exec
+      type: setup
+      params:
+        binary: bash
+        args: [.evergreen/setup-secrets.sh]
+
   "lint and format":
     - command: subprocess.exec
       type: test
@@ -388,14 +395,18 @@ functions:
         file: "astrolabe-src/xunit-output/*.xml"
 
   "upload server logs":
+    - command: ec2.assume_role
+      params:
+        role_arn: ${assume_role_arn}
     - command: s3.put
       type: setup
       params:
-        aws_key: ${aws_key}
-        aws_secret: ${aws_secret}
+        aws_key: ${AWS_ACCESS_KEY_ID}
+        aws_secret: ${AWS_SECRET_ACCESS_KEY}
+        aws_session_token: ${AWS_SESSION_TOKEN}
         local_file: astrolabe-src/logs.tar.gz
-        remote_file: ${project}/${version_id}/${build_id}-${task_id}-${execution}/server-logs.tar.gz
-        bucket: mciuploads
+        remote_file: ${version_id}/${build_id}-${task_id}-${execution}/server-logs.tar.gz
+        bucket: ${aws_bucket}
         permissions: public-read
         content_type: ${content_type|application/x-gzip}
         display_name: "mongodb-logs.tar.gz"
@@ -410,14 +421,18 @@ functions:
         add_expansions_to_env: true
         script: |
           gzip <events.json >events.json.gz
+    - command: ec2.assume_role
+      params:
+      role_arn: ${assume_role_arn}
     - command: s3.put
       type: setup
       params:
-        aws_key: ${aws_key}
-        aws_secret: ${aws_secret}
+        aws_key: ${AWS_ACCESS_KEY_ID}
+        aws_secret: ${AWS_SECRET_ACCESS_KEY}
+        aws_session_token: ${AWS_SESSION_TOKEN}
         local_file: astrolabe-src/events.json.gz
-        remote_file: ${project}/${version_id}/${build_id}-${task_id}-${execution}/events.json.gz
-        bucket: mciuploads
+        remote_file: ${version_id}/${build_id}-${task_id}-${execution}/events.json.gz
+        bucket: ${aws_bucket}
         permissions: public-read
         content_type: ${content_type|application/x-gzip}
         display_name: "events.json.gz"
@@ -426,11 +441,12 @@ functions:
     - command: s3.put
       type: setup
       params:
-        aws_key: ${aws_key}
-        aws_secret: ${aws_secret}
+        aws_key: ${AWS_ACCESS_KEY_ID}
+        aws_secret: ${AWS_SECRET_ACCESS_KEY}
+        aws_session_token: ${AWS_SESSION_TOKEN}
         local_file: astrolabe-src/events.json
-        remote_file: ${project}/${version_id}/${build_id}-${task_id}-${execution}/events.json
-        bucket: mciuploads
+        remote_file: ${version_id}/${build_id}-${task_id}-${execution}/events.json
+        bucket: ${aws_bucket}
         permissions: public-read
         content_type: ${content_type|application/json}
         display_name: "events.json"
@@ -440,6 +456,7 @@ functions:
 pre:
   - func: "fetch source"
   - func: "install astrolabe"
+  - func: "setup secrets"
   - func: "install driver"
 
 # Functions to run after the test.

--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -423,7 +423,7 @@ functions:
           gzip <events.json >events.json.gz
     - command: ec2.assume_role
       params:
-      role_arn: ${assume_role_arn}
+        role_arn: ${assume_role_arn}
     - command: s3.put
       type: setup
       params:
@@ -472,12 +472,6 @@ tasks:
   - name: lint-and-format
     commands:
       - func: "lint and format"
-
-  # Installation:
-  - name: installation
-    commands:
-      - func: "install astrolabe"
-      - func: "install driver"
 
   # Workload executor validation task (patch-only).
   - name: validate-workload-executor

--- a/.evergreen/run-mongodb.sh
+++ b/.evergreen/run-mongodb.sh
@@ -1,35 +1,22 @@
 #!/usr/bin/env bash
 set -o xtrace
 
+if [ ! -f ./secrets-export.sh ]; then
+  echo "Please run setup-secrets.sh first!"
+fi
+
 # User configurable-options
 # Each distro in the download script has a latest download.
 export MONGODB_VERSION=${MONGODB_VERSION:-rapid}
 export TOPOLOGY="server"
 
 # Setup variables
-export DRIVERS_TOOLS="$(dirname $(pwd))/drivers-tools"
-if [ "Windows_NT" = "$OS" ]; then
-   export DRIVERS_TOOLS=$(cygpath -m $DRIVERS_TOOLS)
-fi
 export MONGODB_BINARIES="$DRIVERS_TOOLS/mongodb/bin"
 export MONGO_ORCHESTRATION_HOME="$DRIVERS_TOOLS/.evergreen/orchestration"
 export PATH="$MONGODB_BINARIES:$PATH"
 
-# Clone drivers-evergreen-tools
-git clone --recursive https://github.com/mongodb-labs/drivers-evergreen-tools.git $DRIVERS_TOOLS
-
 # Configure mongo-orchestration
-echo "{ \"releases\": { \"default\": \"$MONGODB_BINARIES\" }}" > $MONGO_ORCHESTRATION_HOME/orchestration.config
-
-# Fix absolute paths
-for filename in $(find ${DRIVERS_TOOLS} -name \*.json); do
-  perl -p -i -e "s|ABSOLUTE_PATH_REPLACEMENT_TOKEN|${DRIVERS_TOOLS}|g" $filename
-done
-
-# Make files executable
-for i in $(find ${DRIVERS_TOOLS}/.evergreen -name \*.sh); do
-  chmod +x $i
-done
+$DRIVERS_TOOLS/.evergreen/setup.sh
 
 # Run mongo-orchestration
 $DRIVERS_TOOLS/.evergreen/run-orchestration.sh

--- a/.evergreen/run-mongodb.sh
+++ b/.evergreen/run-mongodb.sh
@@ -4,6 +4,7 @@ set -o xtrace
 if [ ! -f ./secrets-export.sh ]; then
   echo "Please run setup-secrets.sh first!"
 fi
+source ./secrets-export.sh
 
 # User configurable-options
 # Each distro in the download script has a latest download.

--- a/.evergreen/setup-secrets.sh
+++ b/.evergreen/setup-secrets.sh
@@ -12,7 +12,3 @@ git clone https://github.com/mongodb-labs/drivers-evergreen-tools.git $DRIVERS_T
 . $DRIVERS_TOOLS/.evergreen/secrets_handling/setup-secrets.sh drivers/astrolabe
 
 echo "export DRIVERS_TOOLS=$DRIVERS_TOOLS" >> secrets-export.sh
-
-pwd
-ls
-exit 1

--- a/.evergreen/setup-secrets.sh
+++ b/.evergreen/setup-secrets.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+set -ex
+
+export DRIVERS_TOOLS="$(dirname $(pwd))/drivers-tools"
+if [ "Windows_NT" = "$OS" ]; then
+   export DRIVERS_TOOLS=$(cygpath -m $DRIVERS_TOOLS)
+fi
+
+# Clone drivers-evergreen-tools
+git clone https://github.com/mongodb-labs/drivers-evergreen-tools.git $DRIVERS_TOOLS
+
+. $DRIVERS_TOOLS/.evergreen/secrets_handling/setup-secrets.sh drivers/astrolabe
+
+echo "export DRIVERS_TOOLS=$DRIVERS_TOOLS" >> secrets-export.sh

--- a/.evergreen/setup-secrets.sh
+++ b/.evergreen/setup-secrets.sh
@@ -12,3 +12,7 @@ git clone https://github.com/mongodb-labs/drivers-evergreen-tools.git $DRIVERS_T
 . $DRIVERS_TOOLS/.evergreen/secrets_handling/setup-secrets.sh drivers/astrolabe
 
 echo "export DRIVERS_TOOLS=$DRIVERS_TOOLS" >> secrets-export.sh
+
+pwd
+ls
+exit 1

--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@ logs.tar.gz
 stats.json
 /docs/build
 status
+secrets-export.sh

--- a/astrolabe/cli.py
+++ b/astrolabe/cli.py
@@ -174,6 +174,9 @@ def cli(
         timeout=http_timeout,
     )
 
+    print("do we have an admin user?", atlas_admin_api_username)
+    print("do we have an admin password?", atlas_admin_api_password[:3])
+
     if atlas_admin_api_username:
         admin_client = AtlasClient(
             base_url=atlas_base_url,
@@ -580,6 +583,8 @@ def run_atlas_test(
 
     if os.path.exists("status"):
         os.unlink("status")
+
+    print("do we have an admin client?", ctx.obj.admin_client is not None)
 
     # Initialize the test runner. The test runner constructor performs a bunch of the Atlas setup
     # and can raise exceptions due to Atlas cluster provisioning problems. Treat any exception that

--- a/astrolabe/cli.py
+++ b/astrolabe/cli.py
@@ -174,9 +174,6 @@ def cli(
         timeout=http_timeout,
     )
 
-    print("do we have an admin user?", atlas_admin_api_username)
-    print("do we have an admin password?", atlas_admin_api_password[:3])
-
     if atlas_admin_api_username:
         admin_client = AtlasClient(
             base_url=atlas_base_url,
@@ -583,8 +580,6 @@ def run_atlas_test(
 
     if os.path.exists("status"):
         os.unlink("status")
-
-    print("do we have an admin client?", ctx.obj.admin_client is not None)
 
     # Initialize the test runner. The test runner constructor performs a bunch of the Atlas setup
     # and can raise exceptions due to Atlas cluster provisioning problems. Treat any exception that

--- a/docs/installing-running-locally.md
+++ b/docs/installing-running-locally.md
@@ -138,6 +138,10 @@ export ATLAS_ADMIN_API_PASSWORD=<Admin API Private Key>
 export ATLAS_API_BASE_URL=https://cloud-dev.mongodb.com/api/atlas
 ```
 
+You can fetch the secrets from the drivers AWS vault by configuring your SSO
+and running `bash .evergreen/setup-secrets.sh` and then sourcing the 
+`secrets-export.sh` that is created in the repo root.
+
 Finally, use the `check-connection` command to confirm that `astrolabe`
 is able to connect to and authenticate with the Atlas API:
 


### PR DESCRIPTION
Move all secrets except the `atlas_admin_api_password` to an AWS vault.   That secret should not be shared amongst driver teams.