### PR TITLE
Fix missing workload executor expansions in test runner function.

### DIFF
--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -222,7 +222,7 @@ functions:
           ATLAS_ADMIN_API_USERNAME: ${atlas_admin_api_username}
           ATLAS_ADMIN_API_PASSWORD: ${atlas_admin_api_password}
           CLUSTER_NAME_SALT: ${build_id}
-        include_expansions_in_env: [DRIVER_DIRNAME]
+        include_expansions_in_env: [DRIVER_DIRNAME, PYTHON_BIN_DIR, ASYNC, FRAMEWORK, JAVA_HOME]
         script: |
           source secrets-export.sh
           astrolabevenv/${PYTHON_BIN_DIR}/astrolabe atlas-tests \

--- a/integrations/python/pymongo/install-driver.sh
+++ b/integrations/python/pymongo/install-driver.sh
@@ -1,6 +1,8 @@
 #!/usr/bin/env bash
 set -o xtrace
 
+PYMONGO_VIRTUALENV_NAME=${PYMONGO_VIRTUALENV_NAME:-pymongotestvenv}
+
 "$PYTHON_BINARY" --version
 "$PYTHON_BINARY" -m virtualenv "$PYMONGO_VIRTUALENV_NAME"
 "$PYMONGO_VIRTUALENV_NAME/$PYTHON_BIN_DIR/pip" install -e mongo-python-driver

--- a/integrations/python/pymongo/workload-executor
+++ b/integrations/python/pymongo/workload-executor
@@ -2,4 +2,6 @@
 
 set -o errexit
 
+PYMONGO_VIRTUALENV_NAME=${PYMONGO_VIRTUALENV_NAME:-pymongotestvenv}
+
 "$PYMONGO_VIRTUALENV_NAME/$PYTHON_BIN_DIR/python" "integrations/$DRIVER_DIRNAME/workload-executor.py" "$1" "$2"


### PR DESCRIPTION
Some workload executors need additional environment variables:
- Python needs `PYTHON_BIN_DIR`
- .NET needs `ASYNC` and `FRAMEWORK`
- Java needs `JAVA_HOME`

Add those to the expansions list for the "run atlas test" function.