### PR TITLE
test: increase node startup timeout

### DIFF
--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -682,7 +682,7 @@ axes:
           DRIVER_DIRNAME: "node"
           DRIVER_REPOSITORY: "https://github.com/mongodb/node-mongodb-native"
           DRIVER_REVISION: "main"
-          ASTROLABE_EXECUTOR_STARTUP_TIME: 45
+          ASTROLABE_EXECUTOR_STARTUP_TIME: 60
       - id: java-master
         display_name: "Java (main)"
         variables:


### PR DESCRIPTION
On some tests the workload executor was exiting before the Node tests could start - upped this to 60 seconds now.

Patch with our previous flaky tests: https://spruce.mongodb.com/version/673606d16bb65200075673a1/tasks?sorts=STATUS%3AASC%3BBASE_STATUS%3ADESC

It seems some drivers are failing the workload validator tests that run on PRs only. Those failures are unrelated to Node and its validation tests are passing.