### PR TITLE
Update Rust `workload-executor` script

### DIFF
--- a/integrations/rust/workload-executor
+++ b/integrations/rust/workload-executor
@@ -10,9 +10,6 @@ export CARGO_HOME="$WORKING_DIRECTORY/.cargo"
 
 source $WORKING_DIRECTORY/.cargo/env
 
-# Indicate that the driver should run the workload_executor test
-export ATLAS_PLANNED_MAINTENANCE_TESTING=1
-
 set +x # Hide the connection string in the test output
 export WORKLOAD_EXECUTOR_CONNECTION_STRING="$1"
 export MONGODB_URI="$1"
@@ -25,6 +22,6 @@ export WORKLOAD_EXECUTOR_WORKING_DIRECTORY=$WORKING_DIRECTORY
 cd mongo-rust-driver
 
 # Write the test executable name to exe_name.txt
-cargo test get_exe_name --release -- --ignored
+cargo test get_exe_name --release
 
-RUST_BACKTRACE=1 $(cat exe_name.txt) workload_executor --nocapture -- --release
+RUST_BACKTRACE=1 $(cat exe_name.txt) atlas_planned_maintenance_testing_skip_ci::workload_executor --nocapture -- --release


### PR DESCRIPTION
Updates the Rust `workload-executor` script to accommodate changes made in https://github.com/mongodb/mongo-rust-driver/pull/1303.

full patch: https://spruce.mongodb.com/version/67af943c1e329d00071c1681/tasks?sorts=STATUS%3AASC%3BBASE_STATUS%3ADESC